### PR TITLE
Add() should now use stored provenance for known files.

### DIFF
--- a/niprov/adding.py
+++ b/niprov/adding.py
@@ -54,6 +54,7 @@ def add(filepath, transient=False, provenance=None,
         status = 'dryrun'
     elif repository.knows(img):
         listener.knownFile(img.path)
+        img = repository.byLocation(img.location.toString())
         status = 'known'
     elif repository.knowsSeries(img):
         series = repository.getSeries(img)

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -116,4 +116,10 @@ class AddTests(DependencyInjectionTestBase):
         self.assertEqual(self.lastPath,
             os.path.abspath('p/afile.f'))
 
+    def test_If_file_is_known_return_stored_provenance(self):
+        self.repo.knows.return_value = True
+        (img, status) = self.add('p/afile.f')
+        self.repo.byLocation.assert_called_with(self.img.location.toString())
+        self.assertEqual(img, self.repo.byLocation())
+
 


### PR DESCRIPTION
Fixes #65 

Not sure if this works yet.