### PR TITLE
Transformation provenance field as a prov:Activity

### DIFF
--- a/niprov/formatxml.py
+++ b/niprov/formatxml.py
@@ -77,6 +77,9 @@ class XmlFormat(Format):
                 act.appendChild(actTitle)
                 doc.appendChild(act)
 
+                wasGen = dom.createElementNS(prov, 'prov:wasGeneratedBy')
+                doc.appendChild(wasGen)
+
             doc.appendChild(entity)
 
         return dom.toprettyxml(encoding="UTF-8")

--- a/niprov/formatxml.py
+++ b/niprov/formatxml.py
@@ -68,8 +68,8 @@ class XmlFormat(Format):
             if 'transformation' in item.provenance:
 
                 act = dom.createElementNS(prov, 'prov:activity')
-                actId = entityId+'.xform'
-                act.setAttribute('id', actId)
+                activityId = entityId+'.xform'
+                act.setAttribute('id', activityId)
 
                 actTitle = dom.createElementNS(dct, 'dct:title')
                 actTitleVal = dom.createTextNode(item.provenance['transformation'])
@@ -79,8 +79,10 @@ class XmlFormat(Format):
 
                 wasGen = dom.createElementNS(prov, 'prov:wasGeneratedBy')
                 entityRef = dom.createElementNS(prov, 'prov:entity')
+                entityRef.setAttribute('prov:ref', entityId)
                 wasGen.appendChild(entityRef)
                 activityRef = dom.createElementNS(prov, 'prov:activity')
+                activityRef.setAttribute('prov:ref', activityId)
                 wasGen.appendChild(activityRef)
                 doc.appendChild(wasGen)
 

--- a/niprov/formatxml.py
+++ b/niprov/formatxml.py
@@ -78,6 +78,10 @@ class XmlFormat(Format):
                 doc.appendChild(act)
 
                 wasGen = dom.createElementNS(prov, 'prov:wasGeneratedBy')
+                entityRef = dom.createElementNS(prov, 'prov:entity')
+                wasGen.appendChild(entityRef)
+                activityRef = dom.createElementNS(prov, 'prov:activity')
+                wasGen.appendChild(activityRef)
                 doc.appendChild(wasGen)
 
             doc.appendChild(entity)

--- a/niprov/formatxml.py
+++ b/niprov/formatxml.py
@@ -11,10 +11,12 @@ class XmlFormat(Format):
     def serializeList(self, itemOrList):
         prov = 'http://www.w3.org/ns/prov#'
         nfo = 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#'
+        dct = 'http://purl.org/dc/terms/'
         dom = Document()
         doc = dom.createElementNS(prov, 'prov:document')
         doc.setAttribute('xmlns:prov', prov)
         doc.setAttribute('xmlns:nfo', nfo)
+        doc.setAttribute('xmlns:dct', dct)
         dom.appendChild(doc)
         for i, item in enumerate(itemOrList):
             entity = dom.createElementNS(prov, 'prov:entity')
@@ -26,37 +28,57 @@ class XmlFormat(Format):
             fileUrl.appendChild(fileUrlVal)
             entity.appendChild(fileUrl)
 
-            fileSize = dom.createElementNS(nfo, 'nfo:fileSize')
-            fileSizeVal = dom.createTextNode(str(item.provenance['size']))
-            fileSize.appendChild(fileSizeVal)
-            entity.appendChild(fileSize)
+            if 'size' in item.provenance:
 
-            fileLastMod = dom.createElementNS(nfo, 'nfo:fileLastModified')
-            fileLastModVal = dom.createTextNode(item.provenance['created'].isoformat())
-            fileLastMod.appendChild(fileLastModVal)
-            entity.appendChild(fileLastMod)
+                fileSize = dom.createElementNS(nfo, 'nfo:fileSize')
+                fileSizeVal = dom.createTextNode(str(item.provenance['size']))
+                fileSize.appendChild(fileSizeVal)
+                entity.appendChild(fileSize)
 
-            fileHash = dom.createElementNS(nfo, 'nfo:FileHash')
-            hashId = entityId+'.hash'
-            fileHash.setAttribute('id', hashId)
+            if 'created' in item.provenance:
 
-            hashAlgo = dom.createElementNS(nfo, 'nfo:hashAlgorithm')
-            hashAlgoVal = dom.createTextNode('MD5')
-            hashAlgo.appendChild(hashAlgoVal)
-            fileHash.appendChild(hashAlgo)
+                fileLastMod = dom.createElementNS(nfo, 'nfo:fileLastModified')
+                fileLastModVal = dom.createTextNode(item.provenance['created'].isoformat())
+                fileLastMod.appendChild(fileLastModVal)
+                entity.appendChild(fileLastMod)
 
-            hashValue = dom.createElementNS(nfo, 'nfo:hashValue')
-            hashValueVal = dom.createTextNode(item.provenance['hash'])
-            hashValue.appendChild(hashValueVal)
-            fileHash.appendChild(hashValue)
+            if 'hash' in item.provenance:
 
-            hasHash = dom.createElementNS(nfo, 'nfo:hasHash')
-            hasHashVal = dom.createTextNode(hashId)
-            hasHash.appendChild(hasHashVal)
-            entity.appendChild(hasHash)
+                fileHash = dom.createElementNS(nfo, 'nfo:FileHash')
+                hashId = entityId+'.hash'
+                fileHash.setAttribute('id', hashId)
+
+                hashAlgo = dom.createElementNS(nfo, 'nfo:hashAlgorithm')
+                hashAlgoVal = dom.createTextNode('MD5')
+                hashAlgo.appendChild(hashAlgoVal)
+                fileHash.appendChild(hashAlgo)
+
+                hashValue = dom.createElementNS(nfo, 'nfo:hashValue')
+                hashValueVal = dom.createTextNode(item.provenance['hash'])
+                hashValue.appendChild(hashValueVal)
+                fileHash.appendChild(hashValue)
+
+                hasHash = dom.createElementNS(nfo, 'nfo:hasHash')
+                hasHashVal = dom.createTextNode(hashId)
+                hasHash.appendChild(hasHashVal)
+                entity.appendChild(hasHash)
+
+                doc.appendChild(fileHash)
+
+            if 'transformation' in item.provenance:
+
+                act = dom.createElementNS(prov, 'prov:activity')
+                actId = entityId+'.xform'
+                act.setAttribute('id', actId)
+
+                actTitle = dom.createElementNS(dct, 'dct:title')
+                actTitleVal = dom.createTextNode(item.provenance['transformation'])
+                actTitle.appendChild(actTitleVal)
+                act.appendChild(actTitle)
+                doc.appendChild(act)
 
             doc.appendChild(entity)
-            doc.appendChild(fileHash)
+
         return dom.toprettyxml(encoding="UTF-8")
 
 

--- a/tests/test_formatxml.py
+++ b/tests/test_formatxml.py
@@ -23,150 +23,91 @@ class XmlFormatTests(DependencyInjectionTestBase):
         out = form.serializeList([self.aFile(), self.aFile(), self.aFile()])
         self.assertEqual(3, out.count('<prov:entity'))
 
-    def test_has_PROV_namespace(self):
+    def test_has_namespaces(self):
         from niprov.formatxml import XmlFormat
         form = XmlFormat(self.dependencies)
         out = form.serializeSingle(self.aFile())
-        docline = [l for l in out.split('\n') if 'prov:doc' in l][0]
         prov = 'http://www.w3.org/ns/prov#'
-        nsattr = 'xmlns:prov="{0}"'.format(prov)
-        self.assertIn(nsattr, docline)
-
-    def test_has_NFO_namespace(self):
-        from niprov.formatxml import XmlFormat
-        form = XmlFormat(self.dependencies)
-        out = form.serializeSingle(self.aFile())
-        docline = [l for l in out.split('\n') if 'prov:doc' in l][0]
+        self.assertNamespaceDefined('prov', prov, out)
         nfo = 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#'
-        nsattr = 'xmlns:nfo="{0}"'.format(nfo)
-        self.assertIn(nsattr, docline)
-
-    def test_has_DCT_namespace(self):
-        from niprov.formatxml import XmlFormat
-        form = XmlFormat(self.dependencies)
-        out = form.serializeSingle(self.aFile())
-        docline = [l for l in out.split('\n') if 'prov:doc' in l][0]
+        self.assertNamespaceDefined('nfo', nfo, out)
         dct = 'http://purl.org/dc/terms/'
-        nsattr = 'xmlns:dct="{0}"'.format(dct)
-        self.assertIn(nsattr, docline)
+        self.assertNamespaceDefined('dct', dct, out)
 
     def test_Entity_has_id(self):
         from niprov.formatxml import XmlFormat
         form = XmlFormat(self.dependencies)
         aFile = self.aFile()
-        out = form.serializeSingle(aFile)
-        from xml.dom.minidom import parseString
-        dom = parseString(out)
-        entity = dom.getElementsByTagName("prov:entity")[0]
-        self.assertEqual(entity.attributes['id'].value, 'niprov:file0')
+        doc = self.parseDoc(form.serializeSingle(aFile))
+        entity = doc.getElementsByTagName("prov:entity")[0]
+        self.assertHasAttributeWithValue(entity, 'id', 'niprov:file0')
 
     def test_serialize_file_entity_has_fileUrl_prop(self):
         from niprov.formatxml import XmlFormat
         form = XmlFormat(self.dependencies)
         aFile = self.aFile()
-        out = form.serializeSingle(aFile)
-        from xml.dom.minidom import parseString
-        dom = parseString(out)
-        entity = dom.getElementsByTagName("prov:entity")[0]
-        targetPropElements = entity.getElementsByTagName("nfo:fileUrl")
-        self.assertEqual(1, len(targetPropElements))
-        self.assertEqual(str(aFile.location.toUrl()), 
-            self.getElementContent(targetPropElements[0]))
-
-    def test_serialize_file_entity_has_fileUrl_prop(self):
-        from niprov.formatxml import XmlFormat
-        form = XmlFormat(self.dependencies)
-        aFile = self.aFile()
-        out = form.serializeSingle(aFile)
-        from xml.dom.minidom import parseString
-        dom = parseString(out)
-        entity = dom.getElementsByTagName("prov:entity")[0]
-        targetPropElements = entity.getElementsByTagName("nfo:fileUrl")
-        self.assertEqual(1, len(targetPropElements))
-        self.assertEqual(str(aFile.location.toUrl()), 
-            self.getElementContent(targetPropElements[0]))
+        doc = self.parseDoc(form.serializeSingle(aFile))
+        entity = doc.getElementsByTagName("prov:entity")[0]
+        self.assertOneChildWithTagAndText(entity, 'nfo:fileUrl', 
+            str(aFile.location.toUrl()))
 
     def test_serialize_file_entity_has_fileSize_prop(self):
         from niprov.formatxml import XmlFormat
         form = XmlFormat(self.dependencies)
         aFile = self.aFile()
         aFile.provenance['size'] = 56789
-        out = form.serializeSingle(aFile)
-        from xml.dom.minidom import parseString
-        dom = parseString(out)
-        entity = dom.getElementsByTagName("prov:entity")[0]
-        targetPropElements = entity.getElementsByTagName("nfo:fileSize")
-        self.assertEqual(1, len(targetPropElements))
-        self.assertEqual(str(56789), 
-            self.getElementContent(targetPropElements[0]))
+        doc = self.parseDoc(form.serializeSingle(aFile))
+        entity = doc.getElementsByTagName("prov:entity")[0]
+        self.assertOneChildWithTagAndText(entity, 'nfo:fileSize', str(56789))
 
     def test_serialize_file_entity_has_fileLastModified_prop(self):
         from niprov.formatxml import XmlFormat
         form = XmlFormat(self.dependencies)
         aFile = self.aFile()
         aFile.provenance['created'] = datetime.datetime.now()
-        out = form.serializeSingle(aFile)
-        from xml.dom.minidom import parseString
-        dom = parseString(out)
-        entity = dom.getElementsByTagName("prov:entity")[0]
-        targetPropElements = entity.getElementsByTagName("nfo:fileLastModified")
-        self.assertEqual(1, len(targetPropElements), 'Should have exactly one match')
-        self.assertEqual(aFile.provenance['created'].isoformat(), 
-            self.getElementContent(targetPropElements[0]))
+        doc = self.parseDoc(form.serializeSingle(aFile))
+        entity = doc.getElementsByTagName("prov:entity")[0]
+        self.assertOneChildWithTagAndText(entity, 'nfo:fileLastModified', 
+            aFile.provenance['created'].isoformat())
 
     def test_serialize_file_entity_has_hash(self):
         from niprov.formatxml import XmlFormat
         form = XmlFormat(self.dependencies)
         aFile = self.aFile()
         aFile.provenance['hash'] = 'abraca777'
-        out = form.serializeSingle(aFile)
-        from xml.dom.minidom import parseString
-        dom = parseString(out)
-        entity = dom.getElementsByTagName("prov:entity")[0]
-        #hasHash + FileHash with matching id
-        targetPropElements = entity.getElementsByTagName("nfo:hasHash")
-        self.assertEqual(1, len(targetPropElements))
-        hashref = self.getElementContent(targetPropElements[0])
-        allHashes = dom.getElementsByTagName("nfo:FileHash")
+        doc = self.parseDoc(form.serializeSingle(aFile))
+        entity = doc.getElementsByTagName("prov:entity")[0]
+        hasHash = assertOneChildWithTagName(entity, 'nfo:hasHash')
+        hashref = self.getElementContent(hasHash)
+        allHashes = doc.getElementsByTagName("nfo:FileHash")
         hashesWithId = [e for e in allHashes if e.attributes['id'].value==hashref]
         self.assertEqual(1, len(hashesWithId))
-        hashElement = hashesWithId[0]
+        hashEl = hashesWithId[0]
         #algorithm
-        targetPropElements = hashElement.getElementsByTagName("nfo:hashAlgorithm")
-        self.assertEqual(1, len(targetPropElements), 'Should have exactly one match')
-        self.assertEqual('MD5', 
-            self.getElementContent(targetPropElements[0]))
+        self.assertOneChildWithTagAndText(hashEl, 'nfo:hashAlgorithm', 'MD5')
         #value
-        targetPropElements = hashElement.getElementsByTagName("nfo:hashValue")
-        self.assertEqual(1, len(targetPropElements), 'Should have exactly one match')
-        self.assertEqual(aFile.provenance['hash'], 
-            self.getElementContent(targetPropElements[0]))
+        self.assertOneChildWithTagAndText(hashEl, 'nfo:hashValue', 
+            aFile.provenance['hash'])
 
     def test_FileHash_id_follows_sensible_format(self):
         from niprov.formatxml import XmlFormat
         form = XmlFormat(self.dependencies)
         aFile = self.aFile()
         aFile.provenance['hash'] = 'abraca777'
-        out = form.serializeSingle(aFile)
-        from xml.dom.minidom import parseString
-        dom = parseString(out)
-        entity = dom.getElementsByTagName("prov:entity")[0]
-        targetPropElements = entity.getElementsByTagName("nfo:hasHash")
-        self.assertEqual(1, len(targetPropElements))
-        hashref = self.getElementContent(targetPropElements[0])
-        self.assertEqual(entity.attributes['id'].value+'.hash', hashref)
+        doc = self.parseDoc(form.serializeSingle(aFile))
+        entity = doc.getElementsByTagName("prov:entity")[0]
+        fileId = entity.attributes['id'].value
+        self.assertOneChildWithTagAndText(entity, 'nfo:hasHash', fileId+'.hash')
 
     def test_file_with_transformation_has_activity_w_corresponding_id(self):
         from niprov.formatxml import XmlFormat
         form = XmlFormat(self.dependencies)
         aFile = self.aFile()
         aFile.provenance['transformation'] = 'enchantment'
-        out = form.serializeSingle(aFile)
-        from xml.dom.minidom import parseString
-        dom = parseString(out)
-        entity = dom.getElementsByTagName("prov:entity")[0]
+        doc = self.parseDoc(form.serializeSingle(aFile))
+        entity = doc.getElementsByTagName("prov:entity")[0]
         fileId = entity.attributes['id'].value
-        activity = dom.getElementsByTagName("prov:activity")[0]
+        activity = doc.getElementsByTagName("prov:activity")[0]
         self.assertEqual(fileId+'.xform', activity.attributes['id'].value)
 
     def test_file_with_transformation_has_activity_w_label(self):
@@ -174,15 +115,42 @@ class XmlFormatTests(DependencyInjectionTestBase):
         form = XmlFormat(self.dependencies)
         aFile = self.aFile()
         aFile.provenance['transformation'] = 'enchantment'
-        out = form.serializeSingle(aFile)
+        doc = self.parseDoc(form.serializeSingle(aFile))
+        entity = doc.getElementsByTagName("prov:entity")[0]
+        activity = doc.getElementsByTagName("prov:activity")[0]
+        self.assertOneChildWithTagAndText(activity, 'dct:title', 'enchantment')
+
+    def test_file_with_transformation_has_wasGeneratedBy_element(self):
+        from niprov.formatxml import XmlFormat
+        form = XmlFormat(self.dependencies)
+        aFile = self.aFile()
+        aFile.provenance['transformation'] = 'enchantment'
+        doc = self.parseDoc(form.serializeSingle(aFile))
+        self.assertOneChildWithTagName(doc, "prov:wasGeneratedBy")
+
+    def parseDoc(self, xmlString):
         from xml.dom.minidom import parseString
-        dom = parseString(out)
-        entity = dom.getElementsByTagName("prov:entity")[0]
-        fileId = entity.attributes['id'].value
-        activity = dom.getElementsByTagName("prov:activity")[0]
-        titleElems = activity.getElementsByTagName('dct:title')
-        self.assertEqual(1, len(titleElems))
-        self.assertEqual('enchantment', self.getElementContent(titleElems[0]))
+        dom = parseString(xmlString)
+        return dom.documentElement
+
+    def assertNamespaceDefined(self, prefix, ns, xmlString):
+        doc = self.parseDoc(xmlString)
+        self.assertHasAttributeWithValue(doc, 'xmlns:'+prefix, ns)
+        
+    def assertHasAttributeWithValue(self, element, attName, attValue):
+        assert element.hasAttribute(attName), "Can't find attribute: "+attName
+        self.assertEqual(attValue, element.attributes[attName].value)
+
+    def assertOneChildWithTagName(self, parent, tag):
+        elements = parent.getElementsByTagName(tag)
+        msg = 'Expected exactly one {0} in {1}, but found {2}'
+        nElem = len(elements)
+        self.assertEqual(1, nElem, msg.format(tag, parent.tagName, nElem))
+        return elements[0]
+
+    def assertOneChildWithTagAndText(self, parent, tag, expValue):
+        elem = self.assertOneChildWithTagName(parent, tag)
+        self.assertEqual(expValue, self.getElementContent(elem))
 
     def getElementContent(self, element):
         rc = []

--- a/tests/test_formatxml.py
+++ b/tests/test_formatxml.py
@@ -123,9 +123,14 @@ class XmlFormatTests(DependencyInjectionTestBase):
         aFile = self.aFile()
         aFile.provenance['transformation'] = 'enchantment'
         doc = self.parseDoc(form.serializeSingle(aFile))
+        ent, entId = self.assertOneChildWithTagThatHasAnId(doc, 'prov:entity')
+        act, actId = self.assertOneChildWithTagThatHasAnId(doc, 'prov:activity')
         wasGen = self.assertOneChildWithTagName(doc, "prov:wasGeneratedBy")
-        entity = self.assertOneChildWithTagName(wasGen, "prov:entity")
-        activity = self.assertOneChildWithTagName(wasGen, "prov:activity")
+        refEnt = self.assertOneChildWithTagName(wasGen, "prov:entity")
+        refAct = self.assertOneChildWithTagName(wasGen, "prov:activity")
+        self.assertHasAttributeWithValue(refEnt, 'prov:ref', entId)
+        self.assertHasAttributeWithValue(refAct, 'prov:ref', actId)
+
 
     def parseDoc(self, xmlString):
         from xml.dom.minidom import parseString


### PR DESCRIPTION
Part of #71 

- [x] Create activity element
- [x] Activity has a dct:title
- [x] wasGeneratedBy
- [x] prov:time on wasGeneratedBy 
