### PR TITLE
XmlFormat wasGeneratedBy has a prov:time element.

### DIFF
--- a/niprov/formatxml.py
+++ b/niprov/formatxml.py
@@ -86,6 +86,12 @@ class XmlFormat(Format):
                 wasGen.appendChild(activityRef)
                 doc.appendChild(wasGen)
 
+                if 'created' in item.provenance:
+                    wasGenTime = dom.createElementNS(prov, 'prov:time')
+                    wasGenTimeVal = dom.createTextNode(item.provenance['created'].isoformat())
+                    wasGenTime.appendChild(wasGenTimeVal)
+                    wasGen.appendChild(wasGenTime)
+
             doc.appendChild(entity)
 
         return dom.toprettyxml(encoding="UTF-8")

--- a/tests/test_formatxml.py
+++ b/tests/test_formatxml.py
@@ -131,6 +131,16 @@ class XmlFormatTests(DependencyInjectionTestBase):
         self.assertHasAttributeWithValue(refEnt, 'prov:ref', entId)
         self.assertHasAttributeWithValue(refAct, 'prov:ref', actId)
 
+    def test_file_with_transformation_has_wasGeneratedBy_with_time(self):
+        from niprov.formatxml import XmlFormat
+        form = XmlFormat(self.dependencies)
+        aFile = self.aFile()
+        aFile.provenance['transformation'] = 'enchantment'
+        aFile.provenance['created'] = datetime.datetime.now()
+        doc = self.parseDoc(form.serializeSingle(aFile))
+        wasGen = self.assertOneChildWithTagName(doc, "prov:wasGeneratedBy")
+        self.assertOneChildWithTagAndText(wasGen, 'prov:time', 
+            aFile.provenance['created'].isoformat())
 
     def parseDoc(self, xmlString):
         from xml.dom.minidom import parseString


### PR DESCRIPTION
Part of #71