### PR TITLE
New fields: duration, subject-position, sampling-frequency and water-fat-shift

### DIFF
--- a/docs/source/provenance-fields.rst
+++ b/docs/source/provenance-fields.rst
@@ -25,6 +25,8 @@ Overview of provenance attributes collected:
 +---------------------------------------------+-------------+-------------+---------+-------+-----+-----+
 | :ref:`field-acquired`                       |             | inherited   | yes     | yes   | yes | yes |
 +---------------------------------------------+-------------+-------------+---------+-------+-----+-----+
+| :ref:`field-duration`                       |             | inherited   | yes     | yes   | yes | yes |
++---------------------------------------------+-------------+-------------+---------+-------+-----+-----+
 | :ref:`field-subject`                        |             | inherited   | yes     | yes   | yes | yes |
 +---------------------------------------------+-------------+-------------+---------+-------+-----+-----+
 | :ref:`field-dimensions`                     |             |             | yes     | maybe | yes | yes |
@@ -32,6 +34,10 @@ Overview of provenance attributes collected:
 | :ref:`field-project`                        |             | inherited   |         |       | yes |     |
 +---------------------------------------------+-------------+-------------+---------+-------+-----+-----+
 | :ref:`field-protocol`                       |             | inherited   | yes     | yes   |     |     |
++---------------------------------------------+-------------+-------------+---------+-------+-----+-----+
+| :ref:`field-subject-position`               |             | inherited   | yes     | yes   |     |     |
++---------------------------------------------+-------------+-------------+---------+-------+-----+-----+
+| :ref:`field-water-fat-shift`                |             | inherited   | yes     | yes   |     |     |
 +---------------------------------------------+-------------+-------------+---------+-------+-----+-----+
 | :ref:`field-transformation`                 |             | yes         |         |       |     |     |
 +---------------------------------------------+-------------+-------------+---------+-------+-----+-----+
@@ -46,6 +52,8 @@ Overview of provenance attributes collected:
 | :ref:`field-args`                           |             | yes         |         |       |     |     |
 +---------------------------------------------+-------------+-------------+---------+-------+-----+-----+
 | :ref:`field-kwargs`                         |             | yes         |         |       |     |     |
++---------------------------------------------+-------------+-------------+---------+-------+-----+-----+
+| :ref:`field-sampling-frequency`             |             | inherited   |         |       | yes | yes |
 +---------------------------------------------+-------------+-------------+---------+-------+-----+-----+
 | :ref:`field-seriesuid`                      |             |             |         | yes   |     |     |
 +---------------------------------------------+-------------+-------------+---------+-------+-----+-----+
@@ -139,6 +147,13 @@ acquired
 
 When the data was collected.
 
+.. _field-duration:
+
+duration
+--------
+
+Duration of the acquisition as python datetime.timedelta
+
 .. _field-subject:
 
 subject
@@ -166,6 +181,20 @@ protocol
 --------
 
 The name of the pulse sequence used.
+
+.. _field-subject-position:
+
+subject-position
+----------------
+
+The position and orientation of the subject during during the scan. E.g. head first supine.
+
+.. _field-water-fat-shift:
+
+water-fat-shift
+---------------
+
+Water fat shift value.
 
 .. _field-transformation:
 
@@ -215,6 +244,13 @@ kwargs
 ------
 
 The keyword arguments passed to a python-based transformation command.
+
+.. _field-sampling-frequency:
+
+sampling-frequency
+------------------
+
+How many samples were acquired per second.
 
 .. _field-seriesuid:
 

--- a/niprov/cnt.py
+++ b/niprov/cnt.py
@@ -19,6 +19,8 @@ class NeuroscanFile(BaseFile):
         provenance['subject'] = header.patient.translate(None, '\x00')
         nchannels = unpack('H',header.nchannels)[0]
         numsamples = unpack('I',header.numsamples)[0]
+        sfreq = unpack('H', header.rate)[0]
+        provenance['sampling-frequency'] = sfreq
         provenance['dimensions'] = [nchannels, numsamples]
         acqstring = (header.date+' '+header.time).translate(None, '\x00')
         dtformat = '%d/%m/%y %H:%M:%S'

--- a/niprov/cnt.py
+++ b/niprov/cnt.py
@@ -1,5 +1,6 @@
+from __future__ import division
 from struct import unpack
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 from niprov.basefile import BaseFile
 
 
@@ -22,6 +23,7 @@ class NeuroscanFile(BaseFile):
         sfreq = unpack('H', header.rate)[0]
         provenance['sampling-frequency'] = sfreq
         provenance['dimensions'] = [nchannels, numsamples]
+        provenance['duration'] = timedelta(seconds=numsamples/sfreq)
         acqstring = (header.date+' '+header.time).translate(None, '\x00')
         dtformat = '%d/%m/%y %H:%M:%S'
         provenance['acquired'] = datetime.strptime(acqstring, dtformat)

--- a/niprov/dcm.py
+++ b/niprov/dcm.py
@@ -1,4 +1,4 @@
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 from niprov.basefile import BaseFile
 from niprov.libraries import Libraries
 
@@ -26,6 +26,9 @@ class DicomFile(BaseFile):
         self.provenance['protocol'] = img.SeriesDescription
         self.provenance['seriesuid'] = img.SeriesInstanceUID
         self.provenance['filesInSeries'] = [self.path]
+        self.provenance['duration'] = timedelta(seconds=img.AcquisitionDuration)
+        self.provenance['subject-position'] = img.PatientPosition
+        self.provenance['water-fat-shift'] = img[0x2001, 0x1022].value
         if hasattr(img, 'NumberOfFrames'):
             self.provenance['multiframeDicom'] = True
             nframes = int(img.NumberOfFrames)

--- a/niprov/fif.py
+++ b/niprov/fif.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+from __future__ import division
+from datetime import datetime, timedelta
 from niprov.basefile import BaseFile
 from niprov.libraries import Libraries
 
@@ -29,6 +30,8 @@ class FifFile(BaseFile):
         provenance['acquired'] = datetime.fromtimestamp(acqTS)
         T = img.last_samp - img.first_samp + 1
         provenance['dimensions'] = [img.info['nchan'], T]
+        provenance['sampling-frequency'] = img.info['sfreq']
+        provenance['duration'] = timedelta(seconds=T/img.info['sfreq'])
         return provenance
 
     def attach(self, form='json'):

--- a/niprov/formatjson.py
+++ b/niprov/formatjson.py
@@ -1,6 +1,6 @@
 import json
 import copy
-from datetime import datetime
+from datetime import datetime, timedelta
 from niprov.format import Format
 
 
@@ -9,6 +9,7 @@ class JsonFormat(Format):
     """
 
     datetimeFields = ['acquired','created','added']
+    timedeltaFields = ['duration']
 
     def __init__(self, dependencies):
         super(JsonFormat, self).__init__(dependencies)
@@ -79,6 +80,9 @@ class JsonFormat(Format):
         for field in self.datetimeFields:
             if field in record:
                 flatRecord[field] = record[field].strftime(isoformat)
+        for field in self.timedeltaFields:
+            if field in record:
+                flatRecord[field] = record[field].total_seconds()
         if 'args' in record:
             flatRecord['args'] = [self._strcust(a) for a in record['args']]
         if 'kwargs' in record:
@@ -95,6 +99,9 @@ class JsonFormat(Format):
         for field in self.datetimeFields:
             if field in record:
                 record[field] = datetime.strptime(record[field], isoformat)
+        for field in self.timedeltaFields:
+            if field in record:
+                record[field] = timedelta(seconds=record[field])
         return record
 
     def _strcust(self, val):

--- a/niprov/parrec.py
+++ b/niprov/parrec.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from niprov.basefile import BaseFile
 from niprov.libraries import Libraries
 
@@ -18,6 +18,7 @@ class ParrecFile(BaseFile):
         acqstring = info['exam_date']
         provenance['acquired'] = datetime.strptime(acqstring, dateformat)
         provenance['subject'] = info['patient_name']
+        provenance['subject-position'] = info['patient_position']
         provenance['protocol'] = info['protocol_name']
         provenance['technique'] = info['tech']
         provenance['repetition-time'] = info['repetition_time']
@@ -25,6 +26,8 @@ class ParrecFile(BaseFile):
         provenance['epi-factor'] = info['epi_factor']
         provenance['magnetization-transfer-contrast'] = bool(info['mtc'])
         provenance['diffusion'] = bool(info['diffusion'])
+        provenance['duration'] = timedelta(seconds=info['scan_duration'])
+        provenance['water-fat-shift'] = info['water_fat_shift']
         # per-image
         img0info = img.header.image_defs[0]
         provenance['slice-thickness'] = img0info['slice thickness']

--- a/niprov/parrec.py
+++ b/niprov/parrec.py
@@ -38,5 +38,6 @@ class ParrecFile(BaseFile):
         return provenance
 
     def getProtocolFields(self):
-        return ['repetition-time', 'echo-time', 'flip-angle', 'epi-factor']
+        return ['repetition-time', 'echo-time', 'flip-angle', 'epi-factor', 
+                'water-fat-shift', 'subject-position']
 

--- a/tests/test_cnt.py
+++ b/tests/test_cnt.py
@@ -18,6 +18,7 @@ class CNTTests(BaseFileTests):
         self.assertEqual(out['subject'], 'Jane Doe')
         self.assertEqual(out['dimensions'], [32, 2080])
         self.assertEqual(out['acquired'], datetime(2015,3,9,13,7,3))
+        self.assertEqual(out['sampling-frequency'], 1000)
 
 
 class MockFile(object):
@@ -78,7 +79,7 @@ b' \x00',   #h.nchannels         = self._fread(fid,1,'ushort')
 None,   #h.avgupdate         = self._fread(fid,1,'ushort')
 None,   #h.domain            = self._fread(fid,1,'char')
 None,   #h.variance          = self._fread(fid,1,'char')
-None,   #h.rate              = self._fread(fid,1,'ushort')
+b'\xe8\x03',   #h.rate              = self._fread(fid,1,'ushort')
 None,   #h.scale             = self._fread(fid,1,'double')
 None,   #h.veogcorrect       = self._fread(fid,1,'char')
 None,   #h.heogcorrect       = self._fread(fid,1,'char')

--- a/tests/test_cnt.py
+++ b/tests/test_cnt.py
@@ -1,6 +1,6 @@
 import unittest
 from mock import Mock
-from datetime import datetime
+from datetime import datetime, timedelta
 from tests.test_basefile import BaseFileTests
 
 
@@ -19,6 +19,7 @@ class CNTTests(BaseFileTests):
         self.assertEqual(out['dimensions'], [32, 2080])
         self.assertEqual(out['acquired'], datetime(2015,3,9,13,7,3))
         self.assertEqual(out['sampling-frequency'], 1000)
+        self.assertEqual(out['duration'], timedelta(seconds=2080/1000.))
 
 
 class MockFile(object):

--- a/tests/test_dicomfile.py
+++ b/tests/test_dicomfile.py
@@ -1,6 +1,6 @@
 import unittest
 from mock import Mock, MagicMock, PropertyMock
-from datetime import datetime
+from datetime import datetime, timedelta
 from tests.test_basefile import BaseFileTests
 
 
@@ -46,6 +46,12 @@ class DicomTests(BaseFileTests):
         self.file.addFile(Mock())
         self.assertEqual(out['dimensions'], [11, 12, 2])
 
+    def test_Gets_other_fields(self):
+        out = self.file.inspect()
+        self.assertEqual(out['duration'], timedelta(seconds=65.04713439941406))
+        self.assertEqual(out['subject-position'], 'HFS')
+        self.assertEqual(out['water-fat-shift'], 1.1173381805419922)
+
     def test_File_without_Rows(self):
         del(self.img.Rows)
         out = self.file.inspect()
@@ -59,12 +65,17 @@ class DicomTests(BaseFileTests):
     def setupPydicom(self):
         self.img = Mock()
         self.img.AcquisitionDateTime = '20140805121914.59000'
+        self.img.AcquisitionDuration = 65.04713439941406
         self.img.SeriesDescription = 'T1 SENSE'
         self.img.PatientID = 'John Doeish'
+        self.img.PatientPosition = 'HFS'
         self.img.SeriesInstanceUID = '1.3.46.670589.11.17388.5.0.6340.2011121308140690488'
         self.img.Rows = 11
         self.img.Columns = 12
         self.img.NumberOfFrames = 13
+        wfs = Mock()
+        wfs.value = 1.1173381805419922
+        self.img.__getitem__ = Mock(side_effect=lambda x: {(0x2001, 0x1022):wfs}[x])
         self.libs.dicom.read_file.return_value = self.img
         self.libs.hasDependency.return_value = True
 

--- a/tests/test_fif.py
+++ b/tests/test_fif.py
@@ -1,6 +1,6 @@
 import unittest
 from mock import Mock
-from datetime import datetime
+from datetime import datetime, timedelta
 from tests.test_basefile import BaseFileTests
 
 
@@ -24,6 +24,8 @@ class FifTests(BaseFileTests):
     def test_Gets_dimensions(self):
         out = self.file.inspect()
         self.assertEqual(out['dimensions'], [123, 91])
+        self.assertEqual(out['sampling-frequency'], 200)
+        self.assertEqual(out['duration'], timedelta(seconds=91/200.))
 
     def test_Attach_method(self):
         self.file.getProvenance = Mock()

--- a/tests/test_formatjson.py
+++ b/tests/test_formatjson.py
@@ -2,7 +2,7 @@
 # -*- coding: UTF-8 -*-
 import unittest
 from mock import Mock
-from datetime import datetime
+from datetime import datetime, timedelta
 import json
 from tests.ditest import DependencyInjectionTestBase
 
@@ -32,6 +32,14 @@ class SerializerTests(DependencyInjectionTestBase):
             record['acquired'].isoformat())
         self.assertEqual(json.loads(out)['created'], 
             record['created'].isoformat())
+
+    def test_serialize_makes_timedelta_fields_a_float(self):
+        from niprov.formatjson import JsonFormat  
+        serializer = JsonFormat(self.dependencies)
+        record = {}
+        record['duration'] = timedelta(seconds=12.34)
+        out = serializer.serializeSingle(self.imageWithProvenance(record))
+        self.assertEqual(json.loads(out)['duration'], 12.34)
 
     def test_serialize_makes_args_kwargs_values_strings(self):
         from niprov.formatjson import JsonFormat  
@@ -69,6 +77,14 @@ class SerializerTests(DependencyInjectionTestBase):
         out = serializer.deserialize(json.dumps(record))
         self.assertEqual(out.provenance['acquired'], acquired)
         self.assertEqual(out.provenance['created'], created)
+
+    def test_deserialize_makes_timedelta_field_a_timedelta_object(self):
+        from niprov.formatjson import JsonFormat  
+        serializer = JsonFormat(self.dependencies)
+        record = {}
+        record['duration'] = 23.45
+        out = serializer.deserialize(json.dumps(record))
+        self.assertEqual(out.provenance['duration'], timedelta(seconds=23.45))
 
     def test_serializeList_makes_time_field_a_string(self):
         from niprov.formatjson import JsonFormat  

--- a/tests/test_parrec.py
+++ b/tests/test_parrec.py
@@ -1,6 +1,6 @@
 import unittest
 from mock import Mock
-from datetime import datetime
+from datetime import datetime, timedelta
 from tests.test_basefile import BaseFileTests
 
 
@@ -33,6 +33,9 @@ class ParrecTests(BaseFileTests):
         self.assertEqual(out['epi-factor'], 1)
         self.assertEqual(out['magnetization-transfer-contrast'], False)
         self.assertEqual(out['diffusion'], False)
+        self.assertEqual(out['duration'], timedelta(seconds=65))
+        self.assertEqual(out['subject-position'], 'Head First Supine')
+        self.assertEqual(out['water-fat-shift'], 1.117)
         # per-image
         self.assertEqual(out['slice-thickness'], 10.0)
         self.assertEqual(out['slice-orientation'], 1)


### PR DESCRIPTION
fixes #124 

- [x] CNT sfreq
- [x] CNT duration
- [x] FIF sfreq
- [x] FIF duration  
- [x] PARREC
- [x] DICOM
- [x] docs 
- [x] Serializing `timedelta` duration field: json
- [x] Serializing `timedelta` duration field: bson
- [x] getProtocolFields update PARREC