### PR TITLE
Fix for relative paths of parents and clearer error if file not found

### DIFF
--- a/acceptance/test_contextAPI.py
+++ b/acceptance/test_contextAPI.py
@@ -22,6 +22,13 @@ class ContextApiTests(unittest.TestCase):
         with open(path,'w') as tempfile:
             tempfile.write('0')
 
+    def test_Relative_paths(self):
+        self.provenance.discover('testdata')
+        newfile = 'temp/smoothed.test'
+        self.touch(newfile)
+        self.provenance.log(newfile, 'test', 'testdata/eeg/stub.cnt')
+        img = self.provenance.get(forFile=newfile)
+
     def test_Log(self):
         self.provenance.discover('testdata')
         newfile = 'temp/smoothed.test'

--- a/niprov/adding.py
+++ b/niprov/adding.py
@@ -48,7 +48,6 @@ def add(filepath, transient=False, provenance=None,
     provenance['added'] = datetime.now()
     provenance['id'] = shortuuid.uuid()[:6]
 
-    filepath = os.path.abspath(filepath)
     img = file.locatedAt(filepath, provenance=provenance)
     if config.dryrun:
         status = 'dryrun'
@@ -64,8 +63,9 @@ def add(filepath, transient=False, provenance=None,
         status = 'series'
     else:
         if not transient:
-            if not filesys.fileExists(filepath):
-                raise IOError(errno.ENOENT, 'File not found', filepath)
+            if not filesys.fileExists(img.location.toString()):
+                raise IOError(errno.ENOENT, 'File not found',
+                                                img.location.toString())
             try:
                 img.inspect()
             except:

--- a/niprov/adding.py
+++ b/niprov/adding.py
@@ -63,9 +63,8 @@ def add(filepath, transient=False, provenance=None,
         status = 'series'
     else:
         if not transient:
-            if not filesys.fileExists(img.location.toString()):
-                raise IOError(errno.ENOENT, 'File not found',
-                                                img.location.toString())
+            if not filesys.fileExists(img.location.path):
+                raise IOError(errno.ENOENT, 'File not found', img.location.path)
             try:
                 img.inspect()
             except:

--- a/niprov/location.py
+++ b/niprov/location.py
@@ -1,4 +1,4 @@
-import socket
+import socket, os.path
 
 
 class Location(object):
@@ -8,10 +8,11 @@ class Location(object):
         if ':' in locationString:
             parts = locationString.split(':')
             self.hostname = parts[0]
-            self.path = parts[1]
+            path = parts[1]
         else:
             self.hostname = socket.gethostname()
-            self.path = locationString
+            path = locationString
+        self.path = os.path.abspath(path)
 
     def toDictionary(self):
         d = {}

--- a/niprov/logging.py
+++ b/niprov/logging.py
@@ -78,8 +78,9 @@ def log(new, transformation, parents, code=None, logtext=None, transient=False,
     'subject-position',
     'water-fat-shift',
     ]
+    parents = [location.completeString(p) for p in parents]
     commonProvenance = provenance
-    commonProvenance['parents'] = [location.completeString(p) for p in parents]
+    commonProvenance['parents'] = parents
     commonProvenance['transformation'] = transformation
     commonProvenance['script'] = script
     commonProvenance['user'] = users.determineUser(user)
@@ -87,7 +88,7 @@ def log(new, transformation, parents, code=None, logtext=None, transient=False,
         commonProvenance['code'] = code
     if logtext:
         commonProvenance['logtext'] = logtext
-    if not repository.knowsByLocation(commonProvenance['parents'][0]):
+    if not repository.knowsByLocation(parents[0]):
         (parent, status) = add(parents[0])
         listener.addUnknownParent(parents[0])
     else: 

--- a/niprov/logging.py
+++ b/niprov/logging.py
@@ -88,19 +88,19 @@ def log(new, transformation, parents, code=None, logtext=None, transient=False,
     if logtext:
         commonProvenance['logtext'] = logtext
     if not repository.knowsByLocation(commonProvenance['parents'][0]):
-        add(parents[0])
+        (parent, status) = add(parents[0])
         listener.addUnknownParent(parents[0])
-    parentProvenance = repository.byLocation(
-        commonProvenance['parents'][0]).provenance
+    else: 
+        parent = repository.byLocation(parents[0])
     for field in inheritableFields:
-        if field in parentProvenance:
-            commonProvenance[field] = parentProvenance[field]
+        if field in parent.provenance:
+            commonProvenance[field] = parent.provenance[field]
 
     # do things specific to each new file
     newImages = []
     for newfile in new:
         singleProvenance = copy.deepcopy(commonProvenance)
-        image = add(newfile, transient=transient, provenance=singleProvenance, 
+        (image, status) = add(newfile, transient=transient, provenance=singleProvenance, 
             dependencies=dependencies)
         newImages.append(image)
 

--- a/niprov/mongo.py
+++ b/niprov/mongo.py
@@ -8,6 +8,7 @@ class MongoRepository(object):
     def __init__(self, dependencies=Dependencies()):
         self.config = dependencies.getConfiguration()
         self.factory = dependencies.getFileFactory()
+        self.listener = dependencies.getListener()
         client = pymongo.MongoClient(self.config.database_url)
         self.db = client.get_default_database()
 
@@ -24,6 +25,9 @@ class MongoRepository(object):
             dict: Provenance for one image file.
         """
         record = self.db.provenance.find_one({'location':locationString})
+        if record is None:
+            self.listener.unknownFile(locationString)
+            return
         return self.inflate(record)
 
     def byLocations(self, listOfLocations):
@@ -59,6 +63,9 @@ class MongoRepository(object):
         """
         seriesUid = image.getSeriesId()
         record = self.db.provenance.find_one({'seriesuid':seriesUid})
+        if record is None:
+            self.listener.unknownFile('seriesuid: '+str(seriesUid))
+            return
         return self.inflate(record)
 
     def knowsSeries(self, image):
@@ -144,6 +151,9 @@ class MongoRepository(object):
 
     def byId(self, uid):
         record = self.db.provenance.find_one({'id':uid})
+        if record is None:
+            self.listener.unknownFile('id: '+str(uid))
+            return
         return self.inflate(record)
 
     def byParents(self, listOfParentLocations):

--- a/tests/test_MongoRepo.py
+++ b/tests/test_MongoRepo.py
@@ -1,16 +1,13 @@
 import unittest
 from mock import Mock, patch, sentinel
 from datetime import timedelta
+from tests.ditest import DependencyInjectionTestBase
 
 
-class MongoRepoTests(unittest.TestCase):
+class MongoRepoTests(DependencyInjectionTestBase):
 
     def setUp(self):
-        self.dependencies = Mock()
-        self.config = Mock()
-        self.factory = Mock()
-        self.dependencies.getConfiguration.return_value = self.config
-        self.dependencies.getFileFactory.return_value = self.factory
+        super(MongoRepoTests, self).setUp()
         self.db = Mock()
         self.db.provenance.find_one.return_value = {}
         self.db.provenance.find.return_value = {}
@@ -42,9 +39,9 @@ class MongoRepoTests(unittest.TestCase):
         p = '/p/f1'
         out = self.repo.byLocation(p)
         self.db.provenance.find_one.assert_called_with({'location':p})
-        self.factory.fromProvenance.assert_called_with(
+        self.fileFactory.fromProvenance.assert_called_with(
             self.db.provenance.find_one())
-        self.assertEqual(self.factory.fromProvenance(), out)
+        self.assertEqual(self.fileFactory.fromProvenance(), out)
 
     def test_getSeries(self):
         self.setupRepo()
@@ -52,9 +49,9 @@ class MongoRepoTests(unittest.TestCase):
         out = self.repo.getSeries(img)
         self.db.provenance.find_one.assert_called_with(
             {'seriesuid':img.getSeriesId()})
-        self.factory.fromProvenance.assert_called_with(
+        self.fileFactory.fromProvenance.assert_called_with(
             self.db.provenance.find_one())
-        self.assertEqual(self.factory.fromProvenance(), out)
+        self.assertEqual(self.fileFactory.fromProvenance(), out)
 
     def test_knowsSeries_returns_False_if_no_series_id(self):
         self.setupRepo()
@@ -85,35 +82,35 @@ class MongoRepoTests(unittest.TestCase):
             {'location':img.location.toString()}, {'a':1, 'b':2})
 
     def test_all(self):
-        self.factory.fromProvenance.side_effect = lambda p: 'img_'+p
+        self.fileFactory.fromProvenance.side_effect = lambda p: 'img_'+p
         self.db.provenance.find.return_value = ['p1', 'p2']
         self.setupRepo()
         out = self.repo.all()
         self.db.provenance.find.assert_called_with()
-        self.factory.fromProvenance.assert_any_call('p1')
-        self.factory.fromProvenance.assert_any_call('p2')
+        self.fileFactory.fromProvenance.assert_any_call('p1')
+        self.fileFactory.fromProvenance.assert_any_call('p2')
         self.assertEqual(['img_p1', 'img_p2'], out)
 
     def test_bySubject(self):
-        self.factory.fromProvenance.side_effect = lambda p: 'img_'+p
+        self.fileFactory.fromProvenance.side_effect = lambda p: 'img_'+p
         self.db.provenance.find.return_value = ['p1', 'p2']
         self.setupRepo()
         s = 'Brambo'
         out = self.repo.bySubject(s)
         self.db.provenance.find.assert_called_with({'subject':s})
-        self.factory.fromProvenance.assert_any_call('p1')
-        self.factory.fromProvenance.assert_any_call('p2')
+        self.fileFactory.fromProvenance.assert_any_call('p1')
+        self.fileFactory.fromProvenance.assert_any_call('p2')
         self.assertEqual(['img_p1', 'img_p2'], out)
 
     def test_byApproval(self):
-        self.factory.fromProvenance.side_effect = lambda p: 'img_'+p
+        self.fileFactory.fromProvenance.side_effect = lambda p: 'img_'+p
         self.db.provenance.find.return_value = ['p1', 'p2']
         self.setupRepo()
         a = 'AOk'
         out = self.repo.byApproval(a)
         self.db.provenance.find.assert_called_with({'approval':a})
-        self.factory.fromProvenance.assert_any_call('p1')
-        self.factory.fromProvenance.assert_any_call('p2')
+        self.fileFactory.fromProvenance.assert_any_call('p1')
+        self.fileFactory.fromProvenance.assert_any_call('p2')
         self.assertEqual(['img_p1', 'img_p2'], out)
 
     def test_updateApproval(self):
@@ -126,7 +123,7 @@ class MongoRepoTests(unittest.TestCase):
             {'location':p}, {'$set': {'approval': newStatus}})
 
     def test_latest(self):
-        self.factory.fromProvenance.side_effect = lambda p: 'img_'+p
+        self.fileFactory.fromProvenance.side_effect = lambda p: 'img_'+p
         self.db.provenance.find.return_value = Mock()
         self.db.provenance.find.return_value.sort.return_value.limit.return_value = ['px','py']
         self.setupRepo()
@@ -134,8 +131,8 @@ class MongoRepoTests(unittest.TestCase):
         self.db.provenance.find.assert_called_with()
         self.db.provenance.find().sort.assert_called_with('added', -1)
         self.db.provenance.find().sort().limit.assert_called_with(20)
-        self.factory.fromProvenance.assert_any_call('px')
-        self.factory.fromProvenance.assert_any_call('py')
+        self.fileFactory.fromProvenance.assert_any_call('px')
+        self.fileFactory.fromProvenance.assert_any_call('py')
         self.assertEqual(['img_px', 'img_py'], out)
 
     def test_statistics(self):
@@ -163,28 +160,28 @@ class MongoRepoTests(unittest.TestCase):
         ID = 'abc123'
         out = self.repo.byId(ID)
         self.db.provenance.find_one.assert_called_with({'id':ID})
-        self.factory.fromProvenance.assert_called_with(
+        self.fileFactory.fromProvenance.assert_called_with(
             self.db.provenance.find_one())
-        self.assertEqual(self.factory.fromProvenance(), out)
+        self.assertEqual(self.fileFactory.fromProvenance(), out)
 
     def test_byLocations(self):
-        self.factory.fromProvenance.side_effect = lambda p: 'img_'+p
+        self.fileFactory.fromProvenance.side_effect = lambda p: 'img_'+p
         self.db.provenance.find.return_value = ['p1', 'p2']
         self.setupRepo()
         out = self.repo.byLocations(['l1','l2'])
         self.db.provenance.find.assert_called_with({'location':{'$in':['l1','l2']}})
-        self.factory.fromProvenance.assert_any_call('p1')
-        self.factory.fromProvenance.assert_any_call('p2')
+        self.fileFactory.fromProvenance.assert_any_call('p1')
+        self.fileFactory.fromProvenance.assert_any_call('p2')
         self.assertEqual(['img_p1', 'img_p2'], out)
 
     def test_byParents(self):
-        self.factory.fromProvenance.side_effect = lambda p: 'img_'+p
+        self.fileFactory.fromProvenance.side_effect = lambda p: 'img_'+p
         self.db.provenance.find.return_value = ['p1', 'p2']
         self.setupRepo()
         out = self.repo.byParents(['x1','x2'])
         self.db.provenance.find.assert_called_with({'parents':{'$in':['x1','x2']}})
-        self.factory.fromProvenance.assert_any_call('p1')
-        self.factory.fromProvenance.assert_any_call('p2')
+        self.fileFactory.fromProvenance.assert_any_call('p1')
+        self.fileFactory.fromProvenance.assert_any_call('p2')
         self.assertEqual(['img_p1', 'img_p2'], out)
 
     def test_Converts_timedelta_to_float_when_serializing(self):
@@ -199,13 +196,20 @@ class MongoRepoTests(unittest.TestCase):
         self.setupRepo()
         self.db.provenance.find_one.return_value = {'a':3, 'duration':89.01}
         out = self.repo.byLocation('/p/f1')
-        self.factory.fromProvenance.assert_called_with(
+        self.fileFactory.fromProvenance.assert_called_with(
             {'a':3, 'duration':timedelta(seconds=89.01)})
 
-    def test_If_no_record_returned_byLocation_raises_alarm(self):
+    def test_If_no_record_returned_byLocation_byId_getSeries_raise_alarm(self):
         self.setupRepo()
         self.db.provenance.find_one.return_value = None
-        out = self.repo.byLocation('/p/f1')
+        out = self.repo.byLocation('nowhere')
+        self.listener.unknownFile.assert_called_with('nowhere')
+        out = self.repo.byId('xxxx')
+        self.listener.unknownFile.assert_called_with('id: xxxx')
+        img = Mock()
+        img.getSeriesId.return_value = '123abc'
+        out = self.repo.getSeries(img)
+        self.listener.unknownFile.assert_called_with('seriesuid: 123abc')
         
 
 

--- a/tests/test_MongoRepo.py
+++ b/tests/test_MongoRepo.py
@@ -201,6 +201,11 @@ class MongoRepoTests(unittest.TestCase):
         out = self.repo.byLocation('/p/f1')
         self.factory.fromProvenance.assert_called_with(
             {'a':3, 'duration':timedelta(seconds=89.01)})
+
+    def test_If_no_record_returned_byLocation_raises_alarm(self):
+        self.setupRepo()
+        self.db.provenance.find_one.return_value = None
+        out = self.repo.byLocation('/p/f1')
         
 
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -112,11 +112,6 @@ class AddTests(DependencyInjectionTestBase):
             (provenance, status) = self.add('p/afile.f')
             self.assertEqual(self.lastProvenance['id'],'abcdef')
 
-#    def test_Makes_paths_absolute(self):
-#        (provenance, status) = self.add('p/afile.f')
-#        self.assertEqual(self.lastPath,
-#            os.path.abspath('p/afile.f'))
-
     def test_If_file_is_known_return_stored_provenance(self):
         self.repo.knows.return_value = True
         (img, status) = self.add('p/afile.f')

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -91,8 +91,8 @@ class AddTests(DependencyInjectionTestBase):
 
     def test_If_file_doesnt_exists_tells_listener_and_doesnt_save_prov(self):
         self.filesys.fileExists.return_value = False
-        self.assertRaises(IOError, self.add, self.img.location.toString())
-        self.filesys.fileExists.assert_called_with(self.img.location.toString())
+        self.assertRaises(IOError, self.add, self.img.location.path)
+        self.filesys.fileExists.assert_called_with(self.img.location.path)
 
     def test_For_nonexisting_transient_file_behaves_normal(self):
         self.filesys.fileExists.return_value = False

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -91,7 +91,8 @@ class AddTests(DependencyInjectionTestBase):
 
     def test_If_file_doesnt_exists_tells_listener_and_doesnt_save_prov(self):
         self.filesys.fileExists.return_value = False
-        self.assertRaises(IOError, self.add, 'p/afile.f')
+        self.assertRaises(IOError, self.add, self.img.location.toString())
+        self.filesys.fileExists.assert_called_with(self.img.location.toString())
 
     def test_For_nonexisting_transient_file_behaves_normal(self):
         self.filesys.fileExists.return_value = False
@@ -111,10 +112,10 @@ class AddTests(DependencyInjectionTestBase):
             (provenance, status) = self.add('p/afile.f')
             self.assertEqual(self.lastProvenance['id'],'abcdef')
 
-    def test_Makes_paths_absolute(self):
-        (provenance, status) = self.add('p/afile.f')
-        self.assertEqual(self.lastPath,
-            os.path.abspath('p/afile.f'))
+#    def test_Makes_paths_absolute(self):
+#        (provenance, status) = self.add('p/afile.f')
+#        self.assertEqual(self.lastPath,
+#            os.path.abspath('p/afile.f'))
 
     def test_If_file_is_known_return_stored_provenance(self):
         self.repo.knows.return_value = True

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -55,3 +55,16 @@ class LocationTests(DependencyInjectionTestBase):
         expected = 'file://HAL/p/n1.f'
         self.assertEqual(expected, loc.toUrl())
 
+    def test_Location_makes_relative_paths_absolute(self):
+        from niprov.location import Location
+        with patch('niprov.location.socket') as socket:
+            socket.gethostname.return_value = 'HAL'
+            with patch('niprov.location.os.path') as ospath:
+                ospath.abspath.return_value = '/absolute/path'
+                loc = Location('relative/path')
+                self.assertEqual('/absolute/path', loc.path)
+                self.assertEqual('HAL:/absolute/path', str(loc))
+                loc = Location('KITT:relative/path')
+                self.assertEqual('/absolute/path', loc.path)
+                self.assertEqual('KITT:/absolute/path', str(loc))
+

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -145,5 +145,11 @@ class LoggingTests(DependencyInjectionTestBase):
         provenance = self.log('new', 'trans', parents)
         self.repo.knowsByLocation.assert_called_with(self.provenancesCreated[0]['parents'][0])
         self.repo.byLocation.assert_called_with(self.provenancesCreated[0]['parents'][0])
+
+    def test_If_parent_unknown_does_not_use_byLocation(self):
+        """In this case the parent provenance should be obtained from
+        what add() returns.
+        """
+        self.fail()
         
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -23,12 +23,13 @@ class LoggingTests(DependencyInjectionTestBase):
             'flip-angle':892,
             'inversion-time':123}
         self.repo.byLocation.return_value = img
-        self.newimg = Mock()
-        self.provenancesCreated = []
+        self.provenancesAdded = []
 
         def wrapProv(location, transient=False, provenance=False, dependencies=None):
-            self.provenancesCreated.append(provenance)
-            return self.newimg
+            self.provenancesAdded.append(provenance)
+            self.newimg = Mock()
+            self.newimg.provenance = {'acquired':location}
+            return (self.newimg, 'test')
         self.dependencies.reconfigureOrGetConfiguration.return_value = self.opts
         patcher = patch('niprov.logging.add')
         self.add = patcher.start()
@@ -66,29 +67,29 @@ class LoggingTests(DependencyInjectionTestBase):
         parentImg.provenance = parentProv
         self.repo.byLocation.side_effect = lambda x: {parent:parentImg}[x]
         self.log('new', 'trans', parents)
-        self.assertEqual(self.provenancesCreated[0]['acquired'], parentProv['acquired'])
-        self.assertEqual(self.provenancesCreated[0]['subject'], parentProv['subject'])
-        self.assertEqual(self.provenancesCreated[0]['protocol'], parentProv['protocol'])
-        self.assertEqual(self.provenancesCreated[0]['technique'], parentProv['technique'])
-        self.assertEqual(self.provenancesCreated[0]['repetition-time'], parentProv['repetition-time'])
-        self.assertEqual(self.provenancesCreated[0]['epi-factor'], parentProv['epi-factor'])
-        self.assertEqual(self.provenancesCreated[0]['magnetization-transfer-contrast'], 
+        self.assertEqual(self.provenancesAdded[0]['acquired'], parentProv['acquired'])
+        self.assertEqual(self.provenancesAdded[0]['subject'], parentProv['subject'])
+        self.assertEqual(self.provenancesAdded[0]['protocol'], parentProv['protocol'])
+        self.assertEqual(self.provenancesAdded[0]['technique'], parentProv['technique'])
+        self.assertEqual(self.provenancesAdded[0]['repetition-time'], parentProv['repetition-time'])
+        self.assertEqual(self.provenancesAdded[0]['epi-factor'], parentProv['epi-factor'])
+        self.assertEqual(self.provenancesAdded[0]['magnetization-transfer-contrast'], 
             parentProv['magnetization-transfer-contrast'])
-        self.assertEqual(self.provenancesCreated[0]['diffusion'], parentProv['diffusion'])
-        self.assertEqual(self.provenancesCreated[0]['echo-time'], parentProv['echo-time'])
-        self.assertEqual(self.provenancesCreated[0]['flip-angle'], parentProv['flip-angle'])
-        self.assertEqual(self.provenancesCreated[0]['inversion-time'], parentProv['inversion-time'])
+        self.assertEqual(self.provenancesAdded[0]['diffusion'], parentProv['diffusion'])
+        self.assertEqual(self.provenancesAdded[0]['echo-time'], parentProv['echo-time'])
+        self.assertEqual(self.provenancesAdded[0]['flip-angle'], parentProv['flip-angle'])
+        self.assertEqual(self.provenancesAdded[0]['inversion-time'], parentProv['inversion-time'])
 
     def test_Adds_code_or_logtext(self):
         self.log('new', 'trans', 'old', code='abc', logtext='def')
-        self.assertEqual(self.provenancesCreated[0]['code'],'abc')
-        self.assertEqual(self.provenancesCreated[0]['logtext'],'def')
+        self.assertEqual(self.provenancesAdded[0]['code'],'abc')
+        self.assertEqual(self.provenancesAdded[0]['logtext'],'def')
 
     def test_Determines_user_and_logs_them(self):
         self.users.determineUser.return_value = 'paprika'
         self.log('new', 'trans', 'old', user='mononoko')
         self.users.determineUser.assert_called_with('mononoko')
-        self.assertEqual(self.provenancesCreated[0]['user'],'paprika')
+        self.assertEqual(self.provenancesAdded[0]['user'],'paprika')
 
     def test_Script_added_to_provenance(self):
         parents = ['/p/f1']
@@ -96,7 +97,7 @@ class LoggingTests(DependencyInjectionTestBase):
         trans = 'Something cool'
         script = '/p/test.py'
         self.log(new, trans, parents, script=script)
-        self.assertEqual(self.provenancesCreated[0]['script'], script)
+        self.assertEqual(self.provenancesAdded[0]['script'], script)
 
     def test_Accepts_and_processes_custom_provenance(self):
         parents = ['/p/f1']
@@ -104,14 +105,14 @@ class LoggingTests(DependencyInjectionTestBase):
         trans = 'Something cool'
         p = {'akey':'avalue'}
         self.log(new, trans, parents, provenance=p)
-        self.assertEqual(self.provenancesCreated[0]['akey'], 'avalue')
+        self.assertEqual(self.provenancesAdded[0]['akey'], 'avalue')
 
     def test_Doesnt_complain_if_parent_is_missing_basic_fields(self):
         img = Mock()
         img.provenance = {'acquired':dt.now()} #missing subject
         self.repo.byLocation.return_value = img
         provenance = self.log('new', 'trans', ['/p/f1parent'])
-        self.assertNotIn('subject', self.provenancesCreated[0])
+        self.assertNotIn('subject', self.provenancesAdded[0])
 
     def test_Calls_reconfigureOrGetConfiguration_on_dependencies(self):
         outOpts = Mock()
@@ -127,8 +128,8 @@ class LoggingTests(DependencyInjectionTestBase):
         trans = 'Something cool'
         self.locationFactory.completeString.side_effect = lambda p: 'l:'+p
         self.log(new, trans, parents)
-        self.assertEqual(self.provenancesCreated[0]['parents'], ['l:p1','l:p2'])
-        self.assertEqual(self.provenancesCreated[1]['parents'], ['l:p1','l:p2'])
+        self.assertEqual(self.provenancesAdded[0]['parents'], ['l:p1','l:p2'])
+        self.assertEqual(self.provenancesAdded[1]['parents'], ['l:p1','l:p2'])
 
     def test_Add_parent_if_parent_unknown(self):
         self.repo.knowsByLocation.return_value = False
@@ -143,13 +144,19 @@ class LoggingTests(DependencyInjectionTestBase):
         parent = '/p/f1'
         parents = [parent]
         provenance = self.log('new', 'trans', parents)
-        self.repo.knowsByLocation.assert_called_with(self.provenancesCreated[0]['parents'][0])
-        self.repo.byLocation.assert_called_with(self.provenancesCreated[0]['parents'][0])
+        self.repo.knowsByLocation.assert_called_with(self.provenancesAdded[0]['parents'][0])
 
-    def test_If_parent_unknown_does_not_use_byLocation(self):
+    def test_If_parent_unknown_uses_add_return_value(self):
         """In this case the parent provenance should be obtained from
         what add() returns.
         """
-        self.fail()
+        self.repo.knowsByLocation.return_value = False
+        parent = 'unknown/parent/path.f'
+        provenance = self.log('new', 'trans', [parent])
+        assert not self.repo.byLocation.called
+        loggedFileProv = self.provenancesAdded[1] # [0]: parent [1]: newly logged
+        ## add function is mocked to set 'acquired' field to location passed
+        ## since acquired is an inheritable field, it should show up in kid:
+        self.assertEqual(loggedFileProv['acquired'], 'unknown/parent/path.f')
         
 


### PR DESCRIPTION
fixes #135 
- [x] MongoRepo tells listener about unknownFile() before doing anything else and returns.
- [x] logging should not depend on byLocation() for unknown parent, since during dryrun it will not work.
- [x] fix relative paths bug
- [x] add shouldn't use os.path.abspath since location passed might be full location
- [x] location should do abspath?

In a dryrun, we cannot expect add() to save anything, so we should not expect to get provenance for the parent?
