### PR TITLE
History of file versions at same location.

### DIFF
--- a/acceptance/test_contextAPI.py
+++ b/acceptance/test_contextAPI.py
@@ -113,6 +113,21 @@ class ContextApiTests(unittest.TestCase):
         self.assertIn('MRI', modalities)
         self.assertIn('DWI', modalities)
         self.assertIn('EEG', modalities)
+
+    @unittest.skipIf("TRAVIS" in os.environ, "Work in progress.")
+    def test_Version_history(self):
+        self.provenance.add('f', transient=True, provenance={'a':1})
+        img = self.provenance.get().byLocation('f')
+        self.assertEqual(1, img.provenance['a'])
+        self.provenance.add('f', transient=True, provenance={'a':2})
+        img = self.provenance.get().byLocation('f')
+        self.assertEqual(2, img.provenance['a'])
+        self.assertEqual(1, img.versions[-1]['a'])
+        self.provenance.add('f', transient=True, provenance={'a':3})
+        img = self.provenance.get().byLocation('f')
+        self.assertEqual(3, img.provenance['a'])
+        self.assertEqual(2, img.versions[-1]['a'])
+        self.assertEqual(1, img.versions[-2]['a'])
  
 
 if __name__ == '__main__':

--- a/acceptance/test_contextAPI.py
+++ b/acceptance/test_contextAPI.py
@@ -113,7 +113,6 @@ class ContextApiTests(unittest.TestCase):
         self.assertIn('DWI', modalities)
         self.assertIn('EEG', modalities)
 
-    @unittest.skipIf("TRAVIS" in os.environ, "Work in progress.")
     def test_Version_history(self):
         self.provenance.add('f', transient=True, provenance={'a':1})
         img = self.provenance.get().byLocation('f')

--- a/acceptance/test_contextAPI.py
+++ b/acceptance/test_contextAPI.py
@@ -113,7 +113,7 @@ class ContextApiTests(unittest.TestCase):
         self.assertIn('MRI', modalities)
         self.assertIn('DWI', modalities)
         self.assertIn('EEG', modalities)
-
+ 
 
 if __name__ == '__main__':
     unittest.main()

--- a/acceptance/test_contextAPI.py
+++ b/acceptance/test_contextAPI.py
@@ -85,8 +85,8 @@ class ContextApiTests(unittest.TestCase):
 
     def test_Comparison(self):
         # Given two PARREC images' provenance records
-        par1 = self.provenance.add(abspath('testdata/parrec/T1.PAR'))[0]
-        par2 = self.provenance.add(abspath('testdata/parrec/T2.PAR'))[0]
+        par1 = self.provenance.add(abspath('testdata/parrec/T1.PAR'))
+        par2 = self.provenance.add(abspath('testdata/parrec/T2.PAR'))
         # Comparing them returns a Diff object with methods testing equality
         self.assertFalse(self.provenance.compare(par1, par2).areEqual())
         # Compare() can also be called as a method on the objects themselves,
@@ -96,11 +96,11 @@ class ContextApiTests(unittest.TestCase):
             par1.compare(par2).assertEqualProtocol()
 
     def test_Search(self):
-        x1, s = self.provenance.add('x1', transient=True,
+        x1 = self.provenance.add('x1', transient=True,
             provenance={'transformation':'needle and thread'})
-        x2, s = self.provenance.add('x2/needle.y', transient=True, 
+        x2 = self.provenance.add('x2/needle.y', transient=True, 
             provenance={'transformation':'needle and thread'})
-        x3, s = self.provenance.add('x3', transient=True, 
+        x3 = self.provenance.add('x3', transient=True, 
             provenance={'transformation':'hammer and tongs'})
         results = self.provenance.search('needle')
         self.assertEqual(len(results), 2)

--- a/acceptance/test_contextAPI.py
+++ b/acceptance/test_contextAPI.py
@@ -57,8 +57,7 @@ class ContextApiTests(unittest.TestCase):
         self.assertIsNotNone(self.provenance.get().byLocation(discoveredFile))
         backupFilepath = self.provenance.backup()
         os.remove(self.dbpath) # get rid of existing data.
-        with self.assertRaises(IndexError):
-            self.provenance.get().byLocation(discoveredFile)
+        self.assertIsNone(self.provenance.get().byLocation(discoveredFile))
         self.provenance.importp(backupFilepath)
         self.assertIsNotNone(self.provenance.get().byLocation(discoveredFile))
 

--- a/acceptance/test_contextAPI.py
+++ b/acceptance/test_contextAPI.py
@@ -76,10 +76,10 @@ class ContextApiTests(unittest.TestCase):
 
     def test_Approval(self):
         self.provenance.discover('testdata')
-        self.provenance.markForApproval([os.path.abspath('testdata/dicom/T1.dcm'),
-                                os.path.abspath('testdata/dicom/T2.dcm')])
+        self.provenance.markForApproval(['testdata/parrec/T1.PAR',
+                                'testdata/parrec/T2.PAR'])
         imgs = self.provenance.markedForApproval()
-        self.provenance.approve(os.path.abspath('testdata/dicom/T1.dcm'))
+        self.provenance.approve('testdata/parrec/T1.PAR')
         imgs = self.provenance.markedForApproval()
 
     def test_Comparison(self):

--- a/docs/source/provenance-fields.rst
+++ b/docs/source/provenance-fields.rst
@@ -170,7 +170,7 @@ When the data was collected.
 duration
 --------
 
-Duration of the acquisition as python datetime.timedelta
+Duration of the acquisition in seconds.
 
 .. _field-subject:
 

--- a/niprov/approval.py
+++ b/niprov/approval.py
@@ -13,12 +13,16 @@ def markForApproval(files, reset=False, dependencies=Dependencies()):
             by default.
     """
     repository = dependencies.getRepository()
+    location = dependencies.getLocationFactory()
     for filepath in files:
+        loc = location.completeString(filepath)
         if not reset:
-            image = repository.byLocation(filepath)
+            image = repository.byLocation(loc)
+            if image is None:
+                raise ValueError('Unknown file: '+filepath)
             if image.provenance.get('approval') == 'granted':
                 continue
-        repository.updateApproval(filepath,'pending')
+        repository.updateApproval(loc,'pending')
 
 def markedForApproval(dependencies=Dependencies()):
     """List files marked for approval by a human.
@@ -35,8 +39,9 @@ def approve(filepath, dependencies=Dependencies()):
     Args:
         filepath (str): Path to the tracked file that has been found valid.
     """
-    repository = dependencies.getRepository() 
-    repository.updateApproval(filepath,'granted')
+    loc = dependencies.getLocationFactory().completeString(filepath)
+    repository = dependencies.getRepository()
+    repository.updateApproval(loc, 'granted')
 
 def selectApproved(files, dependencies=Dependencies()):
     """Return only files that have approval status 'granted'.

--- a/niprov/basefile.py
+++ b/niprov/basefile.py
@@ -18,6 +18,7 @@ class BaseFile(object):
             self.provenance = {}
         self.provenance.update(self.location.toDictionary())
         self.path = self.provenance['path']
+        self.status = 'new'
 
     def inspect(self):
         self.provenance['size'] = self.filesystem.getsize(self.path)

--- a/niprov/basefile.py
+++ b/niprov/basefile.py
@@ -51,7 +51,7 @@ class BaseFile(object):
 
     @property
     def versions(self):
-        return self.provenance.get('versions', [])
+        return self.provenance.get('_versions', [])
 
     def compare(self, other):
         return niprov.comparing.compare(self, other, self.dependencies)
@@ -68,11 +68,11 @@ class BaseFile(object):
         return self.pictures.getFilepath(for_=self)
 
     def keepVersionsFromPrevious(self, previous):
-        history = previous.provenance.get('versions', [])
+        history = previous.provenance.get('_versions', [])
         prevprov = copy.copy(previous.provenance)
-        if 'versions' in prevprov:
-            del prevprov['versions']
+        if '_versions' in prevprov:
+            del prevprov['_versions']
         history.append(prevprov)
-        self.provenance['versions'] = history
+        self.provenance['_versions'] = history
         self.status = 'new-version'
 

--- a/niprov/basefile.py
+++ b/niprov/basefile.py
@@ -1,3 +1,4 @@
+import copy
 from niprov.dependencies import Dependencies
 import niprov.comparing
 
@@ -48,6 +49,10 @@ class BaseFile(object):
     def parents(self):
         return self.provenance.get('parents', [])
 
+    @property
+    def versions(self):
+        return self.provenance.get('versions', [])
+
     def compare(self, other):
         return niprov.comparing.compare(self, other, self.dependencies)
 
@@ -61,4 +66,13 @@ class BaseFile(object):
 
     def getSnapshotFilepath(self):
         return self.pictures.getFilepath(for_=self)
+
+    def keepVersionsFromPrevious(self, previous):
+        history = previous.provenance.get('versions', [])
+        prevprov = copy.copy(previous.provenance)
+        if 'versions' in prevprov:
+            del prevprov['versions']
+        history.append(prevprov)
+        self.provenance['versions'] = history
+        self.status = 'new-version'
 

--- a/niprov/cnt.py
+++ b/niprov/cnt.py
@@ -1,6 +1,6 @@
 from __future__ import division
 from struct import unpack
-from datetime import datetime, time, timedelta
+from datetime import datetime
 from niprov.basefile import BaseFile
 
 
@@ -23,7 +23,7 @@ class NeuroscanFile(BaseFile):
         sfreq = unpack('H', header.rate)[0]
         provenance['sampling-frequency'] = sfreq
         provenance['dimensions'] = [nchannels, numsamples]
-        provenance['duration'] = timedelta(seconds=numsamples/sfreq)
+        provenance['duration'] = numsamples/sfreq
         acqstring = (header.date+' '+header.time).translate(None, '\x00')
         dtformat = '%d/%m/%y %H:%M:%S'
         provenance['acquired'] = datetime.strptime(acqstring, dtformat)

--- a/niprov/commandline.py
+++ b/niprov/commandline.py
@@ -37,13 +37,6 @@ class Commandline(object):
         self.log('info', template.format(', '.join(new), transform, 
             ', '.join(parents)))
 
-    def unknownFile(self, fpath):
-        if self.config.dryrun:
-            level = 'info'
-        else:
-            level = 'error'
-        self.log(level, 'Unknown file: '+fpath, UnknownFileError)
-
     def knownFile(self, fpath):
         self.log('info', 'File already known: '+fpath)
 

--- a/niprov/commandline.py
+++ b/niprov/commandline.py
@@ -22,8 +22,6 @@ class Commandline(object):
             nfiles = len(image.provenance['filesInSeries'])
             self.log('info', template.format(ordinal(nfiles), image.getSeriesId()))
         if image.status == 'new-version':
-            template = 'Added {0} file to series: {1}'
-            nfiles = len(image.provenance['filesInSeries'])
             self.log('info', 'Added new version for: {}'.format(image.path))
 
     def missingDependencyForImage(self, lib, fpath):

--- a/niprov/commandline.py
+++ b/niprov/commandline.py
@@ -14,13 +14,17 @@ class Commandline(object):
         self.verbosity = dependencies.config.verbosity
         assert self.verbosity in self.vlevels, "Unknown verbosity value"
 
-    def fileFound(self, image):
-        self.log('info', 'New file: {0}'.format(image.path))
-
-    def fileFoundInSeries(self, img, series):
-        template = 'Adding {0} file to series: {1}'
-        nfiles = len(series.provenance['filesInSeries'])
-        self.log('info', template.format(ordinal(nfiles), series.getSeriesId()))
+    def fileAdded(self, image):
+        if image.status == 'new':
+            self.log('info', 'New file: {0}'.format(image.path))
+        if image.status == 'series-new-file':
+            template = 'Added {0} file to series: {1}'
+            nfiles = len(image.provenance['filesInSeries'])
+            self.log('info', template.format(ordinal(nfiles), image.getSeriesId()))
+        if image.status == 'new-version':
+            template = 'Added {0} file to series: {1}'
+            nfiles = len(image.provenance['filesInSeries'])
+            self.log('info', 'Added new version for: {}'.format(image.path))
 
     def missingDependencyForImage(self, lib, fpath):
         template = 'Missing python package "{0}" to read file: {1}'        
@@ -36,9 +40,6 @@ class Commandline(object):
             'based on [{2}]')
         self.log('info', template.format(', '.join(new), transform, 
             ', '.join(parents)))
-
-    def knownFile(self, fpath):
-        self.log('info', 'File already known: '+fpath)
 
     def renamedDicom(self, fpath):
         self.log('info', 'Renamed dicom file: '+fpath)

--- a/niprov/dcm.py
+++ b/niprov/dcm.py
@@ -72,6 +72,7 @@ class DicomFile(BaseFile):
         """
         self.provenance['filesInSeries'].append(img.path)
         self._updateNfilesDependentFields()
+        return self
 
     def _updateNfilesDependentFields(self):
         if (not self.provenance['multiframeDicom']) and 'dimensions' in self.provenance:

--- a/niprov/dcm.py
+++ b/niprov/dcm.py
@@ -72,6 +72,7 @@ class DicomFile(BaseFile):
         """
         self.provenance['filesInSeries'].append(img.path)
         self._updateNfilesDependentFields()
+        self.status = 'series-new-file'
         return self
 
     def _updateNfilesDependentFields(self):

--- a/niprov/dcm.py
+++ b/niprov/dcm.py
@@ -64,7 +64,7 @@ class DicomFile(BaseFile):
             self.inspect()
         return self.provenance['seriesuid']
 
-    def addFile(self, img):
+    def mergeWith(self, img):
         """
         Add a single DICOM file object to this series.
 

--- a/niprov/dcm.py
+++ b/niprov/dcm.py
@@ -1,4 +1,4 @@
-from datetime import datetime, time, timedelta
+from datetime import datetime
 from niprov.basefile import BaseFile
 from niprov.libraries import Libraries
 
@@ -26,7 +26,7 @@ class DicomFile(BaseFile):
         self.provenance['protocol'] = img.SeriesDescription
         self.provenance['seriesuid'] = img.SeriesInstanceUID
         self.provenance['filesInSeries'] = [self.path]
-        self.provenance['duration'] = timedelta(seconds=img.AcquisitionDuration)
+        self.provenance['duration'] = img.AcquisitionDuration
         self.provenance['subject-position'] = img.PatientPosition
         self.provenance['water-fat-shift'] = img[0x2001, 0x1022].value
         if hasattr(img, 'NumberOfFrames'):

--- a/niprov/discovery.py
+++ b/niprov/discovery.py
@@ -21,15 +21,16 @@ def discover(root, dependencies=Dependencies()):
     listener = dependencies.getListener()
 
     dirs = filesys.walk(root)
-    stats = {'total':0, 'new':0, 'series':0, 'failed':0, 'known':0}
+    stats = {'total':0, 'new':0, 'series-new-file':0, 'failed':0, 
+        'new-version':0}
     for (root, sdirs, files) in dirs:
         for filename in files:
             filepath = os.path.join(root, filename)
             if filefilter.include(filename):
                 stats['total'] = stats['total'] + 1
-                (p, status) = add(filepath, transient=False, 
-                    dependencies=dependencies)
-                stats[status] = stats[status] + 1
-    listener.discoveryFinished(nnew=stats['new'], nadded=stats['series'], 
-        nfailed=stats['failed'], ntotal=stats['total'])
+                p = add(filepath, transient=False, dependencies=dependencies)
+                stats[p.status] = stats[p.status] + 1
+    listener.discoveryFinished(nnew=stats['new'], 
+        nadded=stats['series-new-file'], nfailed=stats['failed'], 
+        ntotal=stats['total'])
 

--- a/niprov/fif.py
+++ b/niprov/fif.py
@@ -1,5 +1,5 @@
 from __future__ import division
-from datetime import datetime, timedelta
+from datetime import datetime
 from niprov.basefile import BaseFile
 from niprov.libraries import Libraries
 
@@ -31,7 +31,7 @@ class FifFile(BaseFile):
         T = img.last_samp - img.first_samp + 1
         provenance['dimensions'] = [img.info['nchan'], T]
         provenance['sampling-frequency'] = img.info['sfreq']
-        provenance['duration'] = timedelta(seconds=T/img.info['sfreq'])
+        provenance['duration'] = T/img.info['sfreq']
         provenance['modality'] = 'MEG'
         return provenance
 

--- a/niprov/formatjson.py
+++ b/niprov/formatjson.py
@@ -8,8 +8,8 @@ class JsonFormat(Format):
     """Helper to convert provenance data to and from json encoded strings.
     """
 
-    datetimeFields = ['acquired','created','added']
-    timedeltaFields = ['duration']
+    datetimeFields = []#['acquired','created','added']
+    timedeltaFields = []#['duration']
 
     def __init__(self, dependencies):
         super(JsonFormat, self).__init__(dependencies)
@@ -27,7 +27,8 @@ class JsonFormat(Format):
         Returns:
             str: Json version of the provenance.
         """
-        return json.dumps(self._deflate(record.provenance))
+        flat = self._deflate(record.provenance)
+        return json.dumps(flat, cls=DateTimeAwareJSONEncoder)
 
     def deserialize(self, jsonRecord):
         """
@@ -41,7 +42,7 @@ class JsonFormat(Format):
         Returns:
             dict: Python dictionary of the provenance.
         """
-        provenance = self._inflate(json.loads(jsonRecord))
+        provenance = json.loads(jsonRecord, cls=DateTimeAwareJSONDecoder)
         return self.file.fromProvenance(provenance)
 
     def serializeList(self, listOfRecords):
@@ -56,7 +57,7 @@ class JsonFormat(Format):
             str: Json version of the provenance items.
         """
         flatRecords = [self._deflate(r.provenance) for r in listOfRecords]
-        return json.dumps(flatRecords)
+        return json.dumps(flatRecords, cls=DateTimeAwareJSONEncoder)
 
     def deserializeList(self, jsonListOfRecords):
         """
@@ -70,19 +71,11 @@ class JsonFormat(Format):
         Returns:
             list: Python list of dictionaries of the provenance.
         """
-        flatRecords = json.loads(jsonListOfRecords)
-        provenanceList = [self._inflate(r) for r in flatRecords]
+        provenanceList = json.loads(jsonListOfRecords, cls=DateTimeAwareJSONDecoder)
         return [self.file.fromProvenance(p) for p in provenanceList]
 
     def _deflate(self, record):
-        isoformat = "%Y-%m-%dT%H:%M:%S.%f"
         flatRecord = copy.deepcopy(record)
-        for field in self.datetimeFields:
-            if field in record:
-                flatRecord[field] = record[field].strftime(isoformat)
-        for field in self.timedeltaFields:
-            if field in record:
-                flatRecord[field] = record[field].total_seconds()
         if 'args' in record:
             flatRecord['args'] = [self._strcust(a) for a in record['args']]
         if 'kwargs' in record:
@@ -93,19 +86,62 @@ class JsonFormat(Format):
             del flatRecord['_id']
         return flatRecord
 
-    def _inflate(self, flatRecord):
-        isoformat = "%Y-%m-%dT%H:%M:%S.%f"
-        record = flatRecord
-        for field in self.datetimeFields:
-            if field in record:
-                record[field] = datetime.strptime(record[field], isoformat)
-        for field in self.timedeltaFields:
-            if field in record:
-                record[field] = timedelta(seconds=record[field])
-        return record
-
     def _strcust(self, val):
         """Stringify an object that is not of a simple type."""
         if not isinstance(val, (str, unicode, int, float, bool, type(None))):
             return str(val)
         return val
+
+# Taken from http://taketwoprogramming.blogspot.com/2009/06/subclassing-jsonencoder-and-jsondecoder.html
+
+class DateTimeAwareJSONEncoder(json.JSONEncoder):
+    """ 
+    Converts a python object, where datetime and timedelta objects are converted
+    into objects that can be decoded using the DateTimeAwareJSONDecoder.
+    """
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            return {
+                '__type__' : 'datetime',
+                'year' : obj.year,
+                'month' : obj.month,
+                'day' : obj.day,
+                'hour' : obj.hour,
+                'minute' : obj.minute,
+                'second' : obj.second,
+                'microsecond' : obj.microsecond,
+            }
+
+        elif isinstance(obj, timedelta):
+            return {
+                '__type__' : 'timedelta',
+                'days' : obj.days,
+                'seconds' : obj.seconds,
+                'microseconds' : obj.microseconds,
+          }
+
+        else:
+            return json.JSONEncoder.default(self, obj)
+
+class DateTimeAwareJSONDecoder(json.JSONDecoder):
+    """ 
+    Converts a json string, where datetime and timedelta objects were converted
+    into objects using the DateTimeAwareJSONEncoder, back into a python object.
+    """
+
+    def __init__(self, **kwargs):
+        json.JSONDecoder.__init__(self, object_hook=self.dict_to_object)
+
+    def dict_to_object(self, d):
+        if '__type__' not in d:
+            return d
+
+        type = d.pop('__type__')
+        if type == 'datetime':
+            return datetime(**d)
+        elif type == 'timedelta':
+            return timedelta(**d)
+        else:
+            # Oops... better put this back together.
+            d['__type__'] = type
+            return d

--- a/niprov/formatjson.py
+++ b/niprov/formatjson.py
@@ -1,15 +1,11 @@
-import json
-import copy
-from datetime import datetime, timedelta
+import json, copy
+from datetime import datetime
 from niprov.format import Format
 
 
 class JsonFormat(Format):
     """Helper to convert provenance data to and from json encoded strings.
     """
-
-    datetimeFields = []#['acquired','created','added']
-    timedeltaFields = []#['duration']
 
     def __init__(self, dependencies):
         super(JsonFormat, self).__init__(dependencies)
@@ -112,14 +108,6 @@ class DateTimeAwareJSONEncoder(json.JSONEncoder):
                 'microsecond' : obj.microsecond,
             }
 
-        elif isinstance(obj, timedelta):
-            return {
-                '__type__' : 'timedelta',
-                'days' : obj.days,
-                'seconds' : obj.seconds,
-                'microseconds' : obj.microseconds,
-          }
-
         else:
             return json.JSONEncoder.default(self, obj)
 
@@ -139,8 +127,6 @@ class DateTimeAwareJSONDecoder(json.JSONDecoder):
         type = d.pop('__type__')
         if type == 'datetime':
             return datetime(**d)
-        elif type == 'timedelta':
-            return timedelta(**d)
         else:
             # Oops... better put this back together.
             d['__type__'] = type

--- a/niprov/jsonfile.py
+++ b/niprov/jsonfile.py
@@ -54,46 +54,6 @@ class JsonFile(object):
             return []
         return self.json.deserializeList(jsonstr)
 
-    def knowsByLocation(self, locationString):
-        """Whether the file at this path has provenance associated with it.
-
-        Returns:
-            bool: True if provenance is available for that path.
-        """
-        try:
-            self.byLocation(locationString)
-        except IndexError:
-            return False
-        return True
-
-    def knows(self, image):
-        """Whether this file has provenance associated with it.
-
-        Returns:
-            bool: True if provenance is available for this image.
-        """
-        try:
-            self.byLocation(image.path)
-        except IndexError:
-            return False
-        return True
-
-    def knowsSeries(self, image):
-        """Whether the series that this file is part of has provenance 
-        associated with it.
-
-        Args:
-            image (:class:`.BaseFile`): File for which the series is sought.
-
-        Returns:
-            bool: True if provenance is available for this series.
-        """
-        try:
-            self.getSeries(image)
-        except IndexError:
-            return False
-        return True
-
     def byLocation(self, locationString):
         """Get the provenance for a file at the given location. 
 

--- a/niprov/jsonfile.py
+++ b/niprov/jsonfile.py
@@ -128,9 +128,9 @@ class JsonFile(object):
         Returns:
             :class:`.DicomFile`: Image object that caries provenance for the series.
         """
-        if image.getSeriesId() is None:
-            raise IndexError('Image has no series id.')
         seriesId = image.getSeriesId()
+        if seriesId is None:
+            return None
         for image in self.all():
             if 'seriesuid' in image.provenance and (
                 image.provenance['seriesuid'] == seriesId):

--- a/niprov/jsonfile.py
+++ b/niprov/jsonfile.py
@@ -69,8 +69,6 @@ class JsonFile(object):
         for image in self.all():
             if image.location.toString() == locationString:
                 return image
-        else:
-            raise IndexError('No file with that path known.')
 
     def byLocations(self, listOfLocations):
         return [f for f in self.all() if f.location.toString() in listOfLocations]
@@ -92,8 +90,6 @@ class JsonFile(object):
             if 'seriesuid' in image.provenance and (
                 image.provenance['seriesuid'] == seriesId):
                 return image
-        else:
-            raise IndexError('No provenance record for that series.')
 
     def updateApproval(self, fpath, approvalStatus):
         img = self.byLocation(fpath)
@@ -118,8 +114,6 @@ class JsonFile(object):
         for image in self.all():
             if image.provenance['id'] == uid:
                 return image
-        else:
-            raise IndexError('No file with that path known.')
 
     def byParents(self, listOfParentLocations):
         return [f for f in self.all() if set(listOfParentLocations).intersection(

--- a/niprov/jsonfile.py
+++ b/niprov/jsonfile.py
@@ -69,9 +69,6 @@ class JsonFile(object):
         for image in self.all():
             if image.location.toString() == locationString:
                 return image
-            elif 'filesInSeries' in image.provenance and (
-                locationString in image.provenance['filesInSeries']):
-                return image
         else:
             raise IndexError('No file with that path known.')
 

--- a/niprov/logging.py
+++ b/niprov/logging.py
@@ -88,11 +88,10 @@ def log(new, transformation, parents, code=None, logtext=None, transient=False,
         commonProvenance['code'] = code
     if logtext:
         commonProvenance['logtext'] = logtext
-    if not repository.knowsByLocation(parents[0]):
-        (parent, status) = add(parents[0])
+    parent = repository.byLocation(parents[0])
+    if parent is None:
+        parent = add(parents[0])
         listener.addUnknownParent(parents[0])
-    else: 
-        parent = repository.byLocation(parents[0])
     for field in inheritableFields:
         if field in parent.provenance:
             commonProvenance[field] = parent.provenance[field]
@@ -101,7 +100,7 @@ def log(new, transformation, parents, code=None, logtext=None, transient=False,
     newImages = []
     for newfile in new:
         singleProvenance = copy.deepcopy(commonProvenance)
-        (image, status) = add(newfile, transient=transient, provenance=singleProvenance, 
+        image = add(newfile, transient=transient, provenance=singleProvenance, 
             dependencies=dependencies)
         newImages.append(image)
 

--- a/niprov/mongo.py
+++ b/niprov/mongo.py
@@ -35,23 +35,6 @@ class MongoRepository(object):
         records = self.db.provenance.find({'location':{'$in':listOfLocations}})
         return [self.inflate(record) for record in records]
 
-    def knowsByLocation(self, locationString):
-        """Whether the file at this location has provenance associated with it.
-
-        Returns:
-            bool: True if provenance is available for that path.
-        """
-        return self.db.provenance.find_one(
-            {'location':locationString}) is not None
-
-    def knows(self, image):
-        """Whether this file has provenance associated with it.
-
-        Returns:
-            bool: True if provenance is available for this image.
-        """
-        return self.knowsByLocation(image.location.toString())
-
     def getSeries(self, image):
         """Get the object that carries provenance for the series that the image 
         passed is in. 
@@ -71,21 +54,6 @@ class MongoRepository(object):
             self.listener.unknownFile('seriesuid: '+str(seriesUid))
             return
         return self.inflate(record)
-
-    def knowsSeries(self, image):
-        """Whether this file is part of a series for which provenance 
-        is available.
-
-        Args:
-            image (:class:`.BaseFile`): File for which the series is sought.
-
-        Returns:
-            bool: True if provenance is available for this series.
-        """
-        seriesUid = image.getSeriesId()
-        if seriesUid is None:
-            return False
-        return self.db.provenance.find_one({'seriesuid':seriesUid}) is not None
 
     def add(self, image):
         """Add the provenance for one file to storage.

--- a/niprov/mongo.py
+++ b/niprov/mongo.py
@@ -64,6 +64,8 @@ class MongoRepository(object):
                          the series.
         """
         seriesUid = image.getSeriesId()
+        if seriesUid is None:
+            return None
         record = self.db.provenance.find_one({'seriesuid':seriesUid})
         if record is None:
             self.listener.unknownFile('seriesuid: '+str(seriesUid))

--- a/niprov/mongo.py
+++ b/niprov/mongo.py
@@ -1,5 +1,4 @@
 import pymongo, copy, bson
-from datetime import timedelta
 from niprov.dependencies import Dependencies
 
 
@@ -124,8 +123,6 @@ class MongoRepository(object):
 
     def deflate(self, img):
         record = copy.deepcopy(img.provenance)
-        if 'duration' in record:
-            record['duration'] = record['duration'].total_seconds()
         snapshotData = self.pictures.getBytes(for_=img)
         if snapshotData:
             record['_snapshot-data'] = bson.Binary(snapshotData)
@@ -134,8 +131,6 @@ class MongoRepository(object):
     def inflate(self, record):
         if record is None:
             return None
-        if 'duration' in record:
-            record['duration'] = timedelta(seconds=record['duration'])
         img = self.factory.fromProvenance(record)
         if '_snapshot-data' in record:
             self.pictures.keep(record['_snapshot-data'], for_=img)

--- a/niprov/parrec.py
+++ b/niprov/parrec.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 import numpy
 from niprov.basefile import BaseFile
 from niprov.libraries import Libraries
@@ -31,7 +31,7 @@ class ParrecFile(BaseFile):
         provenance['epi-factor'] = info['epi_factor']
         provenance['magnetization-transfer-contrast'] = bool(info['mtc'])
         provenance['diffusion'] = bool(info['diffusion'])
-        provenance['duration'] = timedelta(seconds=info['scan_duration'])
+        provenance['duration'] = info['scan_duration']
         provenance['water-fat-shift'] = info['water_fat_shift']
         # per-image
         img0info = img.header.image_defs[0]

--- a/niprov/templates/single.mako
+++ b/niprov/templates/single.mako
@@ -17,6 +17,7 @@
 
 <a href="${request.route_url('pipeline',id=image.provenance.get('id'))}">view pipeline
     <img class="linkicon" src="${request.static_url('niprov:static/pipeline-link.svg')}" alt="pipeline"/></a>
+<a href="#versions">versions</a>
 
 % if image.getSnapshotFilepath():
     <img class="snapshot" src="${request.static_url(image.getSnapshotFilepath())}" alt="snapshot"/>
@@ -48,6 +49,17 @@
     <dt>number of files</dt><dd>${len(image.provenance['filesInSeries'])}</dd>
 % endif
 </dl>
+
+<h2 id="versions">versions</h2>
+<ol>
+% if '_versions' in image.provenance:
+% for version in image.provenance['_versions']:
+    <li>
+        <span class="datetime">${version['added']}</span>
+    </li>
+% endfor
+% endif
+</ol>
 
 <script type="text/javascript" src="${request.static_url('niprov:static/niprov.js')}"></script>
 

--- a/niprov/views.py
+++ b/niprov/views.py
@@ -1,6 +1,7 @@
 from pyramid.view import view_config
 import os
 import niprov.searching as searching
+from pyramid.httpexceptions import HTTPNotFound
 
 
 @view_config(route_name='home', renderer='templates/home.mako')
@@ -16,14 +17,20 @@ def latest(request):
 def short(request):
     sid = request.matchdict['id']
     repository = request.dependencies.getRepository()
-    return {'image':repository.byId(sid)}
+    image = repository.byId(sid)
+    if not image:
+        raise HTTPNotFound
+    return {'image': image}
 
 @view_config(route_name='location', renderer='templates/single.mako')
 def location(request):
     path = os.sep + os.path.join(*request.matchdict['path'])
     loc = request.matchdict['host'] + ':' + path
     repository = request.dependencies.getRepository()
-    return {'image':repository.byLocation(loc)}
+    image = repository.byLocation(loc)
+    if not image:
+        raise HTTPNotFound
+    return {'image': image}
 
 @view_config(route_name='stats', renderer='templates/stats.mako')
 def stats(request):
@@ -35,7 +42,10 @@ def pipeline(request):
     sid = request.matchdict['id']
     files = request.dependencies.getRepository()
     pipeline = request.dependencies.getPipelineFactory()
-    return {'pipeline':pipeline.forFile(files.byId(sid)), 'sid':sid}
+    targetFile = files.byId(sid)
+    if not targetFile:
+        raise HTTPNotFound
+    return {'pipeline':pipeline.forFile(targetFile), 'sid':sid}
 
 @view_config(route_name='subject', renderer='templates/list.mako')
 def subject(request):

--- a/tests/test_MongoRepo.py
+++ b/tests/test_MongoRepo.py
@@ -130,6 +130,13 @@ class MongoRepoTests(DependencyInjectionTestBase):
             self.db.provenance.find_one())
         self.assertEqual(self.fileFactory.fromProvenance(), out)
 
+    def test_If_db_returns_None_should_return_None_for_byId_byLocation(self):
+        self.setupRepo()
+        self.db.provenance.find_one.return_value = None
+        out = self.repo.byId('abc123')
+        assert not self.fileFactory.fromProvenance.called
+        self.assertEqual(None, out)
+
     def test_byLocations(self):
         self.fileFactory.fromProvenance.side_effect = lambda p: 'img_'+p
         self.db.provenance.find.return_value = ['p1', 'p2']
@@ -199,18 +206,6 @@ class MongoRepoTests(DependencyInjectionTestBase):
                                                     '_snapshot-data':'y7yUyS'}
         out = self.repo.byLocation('/p/f1')
         self.pictureCache.keep.assert_called_with('y7yUyS', for_=img)
-
-    def test_If_no_record_returned_byLocation_byId_getSeries_raise_alarm(self):
-        self.setupRepo()
-        self.db.provenance.find_one.return_value = None
-        out = self.repo.byLocation('nowhere')
-        self.listener.unknownFile.assert_called_with('nowhere')
-        out = self.repo.byId('xxxx')
-        self.listener.unknownFile.assert_called_with('id: xxxx')
-        img = Mock()
-        img.getSeriesId.return_value = '123abc'
-        out = self.repo.getSeries(img)
-        self.listener.unknownFile.assert_called_with('seriesuid: 123abc')
 
     def test_Query(self):
         self.db.provenance.find.return_value = ['record1']

--- a/tests/test_MongoRepo.py
+++ b/tests/test_MongoRepo.py
@@ -27,15 +27,6 @@ class MongoRepoTests(DependencyInjectionTestBase):
         pymongo.MongoClient.assert_called_with(self.config.database_url)
         self.assertEqual(pymongo.MongoClient().get_default_database(), repo.db)
 
-    def test_knowsByLocation(self):
-        self.setupRepo()
-        p = '/p/f1'
-        self.db.provenance.find_one.return_value = None
-        self.assertFalse(self.repo.knowsByLocation(p))
-        self.db.provenance.find_one.assert_called_with({'location':p})
-        self.db.provenance.find_one.return_value = 1
-        self.assertTrue(self.repo.knowsByLocation(p))
-
     def test_byLocation_returns_img_from_record_with_path(self):
         self.setupRepo()
         p = '/p/f1'
@@ -55,12 +46,6 @@ class MongoRepoTests(DependencyInjectionTestBase):
             self.db.provenance.find_one())
         self.assertEqual(self.fileFactory.fromProvenance(), out)
 
-    def test_knowsSeries_returns_False_if_no_series_id(self):
-        self.setupRepo()
-        img = Mock()
-        img.getSeriesId.return_value = None
-        self.assertFalse(self.repo.knowsSeries(img))
-
     def test_getSeries_returns_None_right_away_if_no_series_id(self):
         self.setupRepo()
         img = Mock()
@@ -68,13 +53,6 @@ class MongoRepoTests(DependencyInjectionTestBase):
         out = self.repo.getSeries(img)
         assert not self.db.provenance.find_one.called
         self.assertEqual(None, out)
-
-    def test_knowsSeries(self):
-        self.setupRepo()
-        img = Mock()
-        self.assertTrue(self.repo.knowsSeries(img))
-        self.db.provenance.find_one.return_value = None
-        self.assertFalse(self.repo.knowsSeries(img))
 
     def test_Add(self):
         self.setupRepo()

--- a/tests/test_MongoRepo.py
+++ b/tests/test_MongoRepo.py
@@ -61,6 +61,14 @@ class MongoRepoTests(DependencyInjectionTestBase):
         img.getSeriesId.return_value = None
         self.assertFalse(self.repo.knowsSeries(img))
 
+    def test_getSeries_returns_None_right_away_if_no_series_id(self):
+        self.setupRepo()
+        img = Mock()
+        img.getSeriesId.return_value = None
+        out = self.repo.getSeries(img)
+        assert not self.db.provenance.find_one.called
+        self.assertEqual(None, out)
+
     def test_knowsSeries(self):
         self.setupRepo()
         img = Mock()

--- a/tests/test_MongoRepo.py
+++ b/tests/test_MongoRepo.py
@@ -1,6 +1,5 @@
 import unittest
 from mock import Mock, patch, sentinel
-from datetime import timedelta
 from tests.ditest import DependencyInjectionTestBase
 
 
@@ -156,21 +155,6 @@ class MongoRepoTests(DependencyInjectionTestBase):
         self.fileFactory.fromProvenance.assert_any_call('p1')
         self.fileFactory.fromProvenance.assert_any_call('p2')
         self.assertEqual(['img_p1', 'img_p2'], out)
-
-    def test_Converts_timedelta_to_float_when_serializing(self):
-        self.setupRepo()
-        img = Mock()
-        img.provenance = {'a':1, 'duration':timedelta(seconds=67.89)}
-        self.repo.add(img)
-        self.db.provenance.insert_one.assert_called_with(
-            {'a':1, 'duration':67.89})
-
-    def test_Converts_duration_to_timedelta_when_deserializing(self):
-        self.setupRepo()
-        self.db.provenance.find_one.return_value = {'a':3, 'duration':89.01}
-        out = self.repo.byLocation('/p/f1')
-        self.fileFactory.fromProvenance.assert_called_with(
-            {'a':3, 'duration':timedelta(seconds=89.01)})
 
     def test_Obtains_optional_snapshot_data_from_cache_when_serializing(self):
         self.pictureCache.getBytes.return_value = sentinel.snapbytes

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -139,7 +139,7 @@ class AddTests(DependencyInjectionTestBase):
         self.repo.byLocation.return_value = None
         self.repo.getSeries.return_value = series
         image = self.add('p/afile.f')
-        assert not series.addFile.called
+        assert not series.mergeWith.called
         self.img.keepVersionsFromPrevious.assert_called_with(series)
         self.repo.update.assert_any_call(self.img)
 

--- a/tests/test_basefile.py
+++ b/tests/test_basefile.py
@@ -1,5 +1,5 @@
 from tests.ditest import DependencyInjectionTestBase
-from mock import Mock
+from mock import Mock, sentinel
 from datetime import datetime
 
 class BaseFileTests(DependencyInjectionTestBase):
@@ -111,3 +111,19 @@ class BaseFileTests(DependencyInjectionTestBase):
     def test_On_construction_has_status_new(self):
         img = self.constructor(self.path, dependencies=self.dependencies)
         self.assertEqual(img.status, 'new')
+
+    def test_keepVersionsFromPrevious(self):
+        img = self.constructor(self.path, dependencies=self.dependencies)
+        prev = Mock()
+        prev.provenance = {'y':1501, 'versions':[{'y':1499},{'y':1500}]}
+        img.keepVersionsFromPrevious(prev)
+        self.assertEqual('new-version', img.status)
+        self.assertEqual(3, len(img.provenance['versions']))
+        self.assertEqual({'y':1501}, img.provenance['versions'][-1])
+        self.assertEqual({'y':1500}, img.provenance['versions'][-2])
+        self.assertEqual({'y':1499}, img.provenance['versions'][-3])
+
+    def test_versions_property_access(self):
+        img = self.constructor(self.path, dependencies=self.dependencies)
+        img.provenance = {'versions':sentinel.versions}
+        self.assertEqual(img.provenance['versions'], img.versions)

--- a/tests/test_basefile.py
+++ b/tests/test_basefile.py
@@ -107,3 +107,7 @@ class BaseFileTests(DependencyInjectionTestBase):
                                 provenance={'modality':'magic'})
         img.inspect()
         self.assertEqual(img.provenance['modality'], 'magic')
+
+    def test_On_construction_has_status_new(self):
+        img = self.constructor(self.path, dependencies=self.dependencies)
+        self.assertEqual(img.status, 'new')

--- a/tests/test_basefile.py
+++ b/tests/test_basefile.py
@@ -115,15 +115,15 @@ class BaseFileTests(DependencyInjectionTestBase):
     def test_keepVersionsFromPrevious(self):
         img = self.constructor(self.path, dependencies=self.dependencies)
         prev = Mock()
-        prev.provenance = {'y':1501, 'versions':[{'y':1499},{'y':1500}]}
+        prev.provenance = {'y':1501, '_versions':[{'y':1499},{'y':1500}]}
         img.keepVersionsFromPrevious(prev)
         self.assertEqual('new-version', img.status)
-        self.assertEqual(3, len(img.provenance['versions']))
-        self.assertEqual({'y':1501}, img.provenance['versions'][-1])
-        self.assertEqual({'y':1500}, img.provenance['versions'][-2])
-        self.assertEqual({'y':1499}, img.provenance['versions'][-3])
+        self.assertEqual(3, len(img.provenance['_versions']))
+        self.assertEqual({'y':1501}, img.provenance['_versions'][-1])
+        self.assertEqual({'y':1500}, img.provenance['_versions'][-2])
+        self.assertEqual({'y':1499}, img.provenance['_versions'][-3])
 
     def test_versions_property_access(self):
         img = self.constructor(self.path, dependencies=self.dependencies)
-        img.provenance = {'versions':sentinel.versions}
-        self.assertEqual(img.provenance['versions'], img.versions)
+        img.provenance = {'_versions':sentinel.versions}
+        self.assertEqual(img.provenance['_versions'], img.versions)

--- a/tests/test_cnt.py
+++ b/tests/test_cnt.py
@@ -1,6 +1,6 @@
 import unittest
 from mock import Mock
-from datetime import datetime, timedelta
+from datetime import datetime
 from tests.test_basefile import BaseFileTests
 
 
@@ -19,7 +19,7 @@ class CNTTests(BaseFileTests):
         self.assertEqual(out['dimensions'], [32, 2080])
         self.assertEqual(out['acquired'], datetime(2015,3,9,13,7,3))
         self.assertEqual(out['sampling-frequency'], 1000)
-        self.assertEqual(out['duration'], timedelta(seconds=2080/1000.))
+        self.assertEqual(out['duration'], 2080/1000.)
 
     def test_Determines_modality(self):
         out = self.file.inspect()

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -34,3 +34,22 @@ class CommandlineTests(DependencyInjectionTestBase):
         cmd.addUnknownParent('backupfile.x')
         cmd.log.assert_called_with('warning', 'backupfile.x unknown. Adding to provenance')
 
+    def test_fileAdded(self):
+        from niprov.commandline import Commandline
+        self.dependencies.config.verbosity = 'info'
+        cmd = Commandline(self.dependencies)
+        cmd.log = Mock()
+        img = Mock()
+        img.path = 'xyz'
+        img.status = 'new'
+        cmd.fileAdded(img)
+        cmd.log.assert_called_with('info', 'New file: xyz')
+        img.status = 'series-new-file'
+        img.provenance = {'filesInSeries':[1, 2, 3]}
+        img.getSeriesId.return_value = 'series987'
+        cmd.fileAdded(img)
+        cmd.log.assert_called_with('info', 'Added 3rd file to series: series987')
+        img.status = 'new-version'
+        cmd.fileAdded(img)
+        cmd.log.assert_called_with('info', 'Added new version for: xyz')
+

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -8,13 +8,6 @@ class CommandlineTests(DependencyInjectionTestBase):
     def setUp(self):
         super(CommandlineTests, self).setUp()
 
-    def test_raises_exception_for_unknown_file(self):
-        from niprov.commandline import Commandline
-        from niprov.exceptions import UnknownFileError
-        cmd = Commandline()
-        with self.assertRaisesRegexp(UnknownFileError, '.* /foo/bar.baz'):
-            cmd.unknownFile('/foo/bar.baz')
-
     def test_Only_prints_if_appropriate_verbosity_setting(self):
         from niprov.commandline import Commandline
         self.dependencies.config.verbosity = 'warning'
@@ -24,21 +17,6 @@ class CommandlineTests(DependencyInjectionTestBase):
             assert not mprint.called
             cmd.log('warning','Watch out!')
             mprint.assert_called_with('[provenance:warning] Watch out!')
-
-    def test_If_on_dryrun_mode_an_unknown_file_is_not_an_error(self):
-        from niprov.commandline import Commandline
-        from niprov.exceptions import UnknownFileError
-        self.dependencies.config.verbosity = 'warning' #default
-        self.dependencies.config.dryrun = False
-        cmd = Commandline(self.dependencies)
-        cmd.log = Mock()
-        cmd.unknownFile('abc')
-        cmd.log.assert_called_with('error','Unknown file: abc', UnknownFileError)
-        self.dependencies.config.dryrun = True
-        cmd = Commandline(self.dependencies)
-        cmd.log = Mock()
-        cmd.unknownFile('abc')
-        cmd.log.assert_called_with('info','Unknown file: abc', UnknownFileError)
 
     def test_exportedToFile_logs_info(self):
         from niprov.commandline import Commandline

--- a/tests/test_dicomfile.py
+++ b/tests/test_dicomfile.py
@@ -37,6 +37,7 @@ class DicomTests(BaseFileTests):
         out = self.file.addFile(newFile)
         self.assertIn(newFile.path, self.file.provenance['filesInSeries'])
         self.assertEqual(self.file, out)
+        self.assertEqual('series-new-file', self.file.status)
 
     def test_Gets_dimensions(self):
         out = self.file.inspect()

--- a/tests/test_dicomfile.py
+++ b/tests/test_dicomfile.py
@@ -1,6 +1,6 @@
 import unittest
 from mock import Mock, MagicMock, PropertyMock
-from datetime import datetime, timedelta
+from datetime import datetime
 from tests.test_basefile import BaseFileTests
 
 
@@ -50,7 +50,7 @@ class DicomTests(BaseFileTests):
 
     def test_Gets_other_fields(self):
         out = self.file.inspect()
-        self.assertEqual(out['duration'], timedelta(seconds=65.04713439941406))
+        self.assertEqual(out['duration'], 65.04713439941406)
         self.assertEqual(out['subject-position'], 'HFS')
         self.assertEqual(out['water-fat-shift'], 1.1173381805419922)
 

--- a/tests/test_dicomfile.py
+++ b/tests/test_dicomfile.py
@@ -34,7 +34,7 @@ class DicomTests(BaseFileTests):
         self.assertEqual(self.file.getSeriesId(), self.img.SeriesInstanceUID)
         self.assertIn(self.file.path, self.file.provenance['filesInSeries'])
         newFile = Mock()
-        out = self.file.addFile(newFile)
+        out = self.file.mergeWith(newFile)
         self.assertIn(newFile.path, self.file.provenance['filesInSeries'])
         self.assertEqual(self.file, out)
         self.assertEqual('series-new-file', self.file.status)
@@ -45,7 +45,7 @@ class DicomTests(BaseFileTests):
         del(self.img.NumberOfFrames)
         out = self.file.inspect()
         self.assertEqual(out['dimensions'], [11, 12, 1])
-        self.file.addFile(Mock())
+        self.file.mergeWith(Mock())
         self.assertEqual(out['dimensions'], [11, 12, 2])
 
     def test_Gets_other_fields(self):
@@ -61,7 +61,7 @@ class DicomTests(BaseFileTests):
         self.assertNotIn('dimensions', out)
         del(self.img.NumberOfFrames)
         out = self.file.inspect()
-        self.file.addFile(Mock())
+        self.file.mergeWith(Mock())
         assert not self.listener.fileError.called
 
     def test_Determines_modality(self):

--- a/tests/test_dicomfile.py
+++ b/tests/test_dicomfile.py
@@ -34,8 +34,9 @@ class DicomTests(BaseFileTests):
         self.assertEqual(self.file.getSeriesId(), self.img.SeriesInstanceUID)
         self.assertIn(self.file.path, self.file.provenance['filesInSeries'])
         newFile = Mock()
-        self.file.addFile(newFile)
+        out = self.file.addFile(newFile)
         self.assertIn(newFile.path, self.file.provenance['filesInSeries'])
+        self.assertEqual(self.file, out)
 
     def test_Gets_dimensions(self):
         out = self.file.inspect()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -11,7 +11,9 @@ class DiscoveryTests(unittest.TestCase):
         self.listener = Mock()
         self.filt = Mock()
         self.add = Mock()
-        self.add.return_value = (Mock(), 'new')
+        img = Mock()
+        img.status = 'new'
+        self.add.return_value = img
         self.dependencies = Mock()
         self.dependencies.getFilesystem.return_value = self.filesys
         self.dependencies.getListener.return_value = self.listener
@@ -41,9 +43,14 @@ class DiscoveryTests(unittest.TestCase):
 
     def test_Gives_listener_summary(self):
         self.filesys.walk.return_value = [('root',[],['a','b','c','d','e','f','g','h'])]
-        a,b,c,d,e,f,g,h = [(Mock(), s) for s in ['new','new','series','series',
-            'series','failed','known','known']]
-        self.add.side_effect = [a,b,c,d,e,f,g,h]
+        statuses = ['new','new','series-new-file','series-new-file', 
+            'series-new-file','failed','new-version','new-version']
+        images = []
+        for s in statuses:
+            img = Mock()
+            img.status = s
+            images.append(img)
+        self.add.side_effect = images
         self.discover('root')
         self.listener.discoveryFinished.assert_called_with(nnew=2, nadded=3, nfailed=1, ntotal=8)
 

--- a/tests/test_fif.py
+++ b/tests/test_fif.py
@@ -1,6 +1,6 @@
 import unittest
 from mock import Mock
-from datetime import datetime, timedelta
+from datetime import datetime
 from tests.test_basefile import BaseFileTests
 
 
@@ -25,7 +25,7 @@ class FifTests(BaseFileTests):
         out = self.file.inspect()
         self.assertEqual(out['dimensions'], [123, 91])
         self.assertEqual(out['sampling-frequency'], 200)
-        self.assertEqual(out['duration'], timedelta(seconds=91/200.))
+        self.assertEqual(out['duration'], 91/200.)
 
     def test_Attach_method(self):
         self.file.getProvenance = Mock()

--- a/tests/test_formatjson.py
+++ b/tests/test_formatjson.py
@@ -2,7 +2,7 @@
 # -*- coding: UTF-8 -*-
 import unittest
 from mock import Mock
-from datetime import datetime, timedelta
+from datetime import datetime
 import json
 from tests.ditest import DependencyInjectionTestBase
 
@@ -60,11 +60,10 @@ class SerializerTests(DependencyInjectionTestBase):
         record = {}
         dtnow = datetime.now()
         record['versions'] = [{'acquired':dtnow}, 
-                              {'duration':timedelta(seconds=23.45)}]
+                              {'added':dtnow}]
         jsonStr = serializer.serializeSingle(self.imageWithProvenance(record))
         out = serializer.deserialize(jsonStr)
-        self.assertEqual(out.provenance['versions'][-1]['duration'], 
-            timedelta(seconds=23.45))
+        self.assertEqual(out.provenance['versions'][-1]['added'], dtnow)
         self.assertEqual(out.provenance['versions'][-2]['acquired'], dtnow)
 
 

--- a/tests/test_formatjson.py
+++ b/tests/test_formatjson.py
@@ -20,27 +20,6 @@ class SerializerTests(DependencyInjectionTestBase):
             img.location.toString.return_value = prov['location']
         return img
 
-    def test_serialize_makes_time_fields_a_string(self):
-        from niprov.formatjson import JsonFormat  
-        serializer = JsonFormat(self.dependencies)
-        record = {}
-        record['acquired'] = datetime.now()
-        record['created'] = datetime.now()
-        record['added'] = datetime.now()
-        out = serializer.serializeSingle(self.imageWithProvenance(record))
-        self.assertEqual(json.loads(out)['acquired'], 
-            record['acquired'].isoformat())
-        self.assertEqual(json.loads(out)['created'], 
-            record['created'].isoformat())
-
-    def test_serialize_makes_timedelta_fields_a_float(self):
-        from niprov.formatjson import JsonFormat  
-        serializer = JsonFormat(self.dependencies)
-        record = {}
-        record['duration'] = timedelta(seconds=12.34)
-        out = serializer.serializeSingle(self.imageWithProvenance(record))
-        self.assertEqual(json.loads(out)['duration'], 12.34)
-
     def test_serialize_makes_args_kwargs_values_strings(self):
         from niprov.formatjson import JsonFormat  
         class CustomType(object):
@@ -66,38 +45,6 @@ class SerializerTests(DependencyInjectionTestBase):
         out = serializer.deserialize(jsonrecord)
         self.assertEqual(img1.provenance, out.provenance)
 
-    def test_deserialize_makes_time_field_a_datetime_object(self):
-        from niprov.formatjson import JsonFormat  
-        serializer = JsonFormat(self.dependencies)
-        record = {}
-        acquired = datetime.now()
-        record['acquired'] = acquired.isoformat()      
-        created = datetime.now()
-        record['created'] = created.isoformat()      
-        out = serializer.deserialize(json.dumps(record))
-        self.assertEqual(out.provenance['acquired'], acquired)
-        self.assertEqual(out.provenance['created'], created)
-
-    def test_deserialize_makes_timedelta_field_a_timedelta_object(self):
-        from niprov.formatjson import JsonFormat  
-        serializer = JsonFormat(self.dependencies)
-        record = {}
-        record['duration'] = 23.45
-        out = serializer.deserialize(json.dumps(record))
-        self.assertEqual(out.provenance['duration'], timedelta(seconds=23.45))
-
-    def test_serializeList_makes_time_field_a_string(self):
-        from niprov.formatjson import JsonFormat  
-        serializer = JsonFormat(self.dependencies)
-        record = {}
-        record['acquired'] = datetime.now()
-        record['created'] = datetime.now()
-        out = serializer.serializeList([self.imageWithProvenance(record)])
-        self.assertEqual(json.loads(out)[0]['acquired'], 
-            record['acquired'].isoformat())
-        self.assertEqual(json.loads(out)[0]['created'], 
-            record['created'].isoformat())
-
     def test_swallows_object_ids(self):
         from bson.objectid import ObjectId
         from niprov.formatjson import JsonFormat  
@@ -106,5 +53,18 @@ class SerializerTests(DependencyInjectionTestBase):
         record['_id'] = ObjectId('564168f2fb481f480891263c')
         out = serializer.serializeList([self.imageWithProvenance(record)])
         self.assertNotIn('_id', json.loads(out)[0])
+
+    def test_Deals_with_versions(self):
+        from niprov.formatjson import JsonFormat  
+        serializer = JsonFormat(self.dependencies)
+        record = {}
+        dtnow = datetime.now()
+        record['versions'] = [{'acquired':dtnow}, 
+                              {'duration':timedelta(seconds=23.45)}]
+        jsonStr = serializer.serializeSingle(self.imageWithProvenance(record))
+        out = serializer.deserialize(jsonStr)
+        self.assertEqual(out.provenance['versions'][-1]['duration'], 
+            timedelta(seconds=23.45))
+        self.assertEqual(out.provenance['versions'][-2]['acquired'], dtnow)
 
 

--- a/tests/test_formatjson.py
+++ b/tests/test_formatjson.py
@@ -59,11 +59,11 @@ class SerializerTests(DependencyInjectionTestBase):
         serializer = JsonFormat(self.dependencies)
         record = {}
         dtnow = datetime.now()
-        record['versions'] = [{'acquired':dtnow}, 
+        record['_versions'] = [{'acquired':dtnow}, 
                               {'added':dtnow}]
         jsonStr = serializer.serializeSingle(self.imageWithProvenance(record))
         out = serializer.deserialize(jsonStr)
-        self.assertEqual(out.provenance['versions'][-1]['added'], dtnow)
-        self.assertEqual(out.provenance['versions'][-2]['acquired'], dtnow)
+        self.assertEqual(out.provenance['_versions'][-1]['added'], dtnow)
+        self.assertEqual(out.provenance['_versions'][-2]['acquired'], dtnow)
 
 

--- a/tests/test_jsonfile.py
+++ b/tests/test_jsonfile.py
@@ -53,16 +53,6 @@ class JsonFileTest(DependencyInjectionTestBase):
         out = repo.byLocation('2')
         self.assertEqual(img2, out)
 
-    def test_byLocation_works_for_file_in_series(self):
-        from niprov.jsonfile import JsonFile
-        repo = JsonFile(self.dependencies)
-        img1 = self.imageWithProvenance({'location':'1','path':'a'})
-        img3 = self.imageWithProvenance({'location':'3','filesInSeries':['boo','bah']})
-        repo.all = Mock()
-        repo.all.return_value = [img1, img3]
-        out = repo.byLocation('boo')
-        self.assertEqual(img3, out)
-
     def test_updateApproval(self):
         from niprov.jsonfile import JsonFile
         repo = JsonFile(self.dependencies)

--- a/tests/test_jsonfile.py
+++ b/tests/test_jsonfile.py
@@ -43,14 +43,6 @@ class JsonFileTest(DependencyInjectionTestBase):
         self.filesys.write.assert_called_with(repo.datafile, 
             self.serializer.serializeList())
 
-    def test_knowsByLocation(self):
-        from niprov.jsonfile import JsonFile
-        repo = JsonFile(self.dependencies)
-        repo.byLocation = Mock()
-        self.assertTrue(repo.knowsByLocation(''))
-        repo.byLocation.side_effect = IndexError
-        self.assertFalse(repo.knowsByLocation(''))
-
     def test_byLocation(self):
         from niprov.jsonfile import JsonFile
         repo = JsonFile(self.dependencies)

--- a/tests/test_jsonfile.py
+++ b/tests/test_jsonfile.py
@@ -285,3 +285,25 @@ class JsonFileTest(DependencyInjectionTestBase):
         self.assertIn('blue', out)
         self.assertEqual(3, len(out))
 
+    def test_getSeries(self):
+        from niprov.jsonfile import JsonFile
+        repo = JsonFile(self.dependencies)
+        img = Mock()
+        img.getSeriesId.return_value = '2'
+        img1 = self.imageWithProvenance({'seriesuid':'1','path':'a'})
+        img2 = self.imageWithProvenance({'seriesuid':'2','path':'b'})
+        repo.all = Mock()
+        repo.all.return_value = [img1, img2]
+        out = repo.getSeries(img)
+        self.assertEqual(img2, out)
+
+    def test_getSeries_returns_None_right_away_if_no_series_id(self):
+        from niprov.jsonfile import JsonFile
+        repo = JsonFile(self.dependencies)
+        img = Mock()
+        img.getSeriesId.return_value = None
+        repo.all = Mock()
+        out = repo.getSeries(img)
+        assert not repo.all.called, "Should not be called if no series id"
+        self.assertEqual(None, out)
+

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -7,7 +7,7 @@ class LoggingTests(DependencyInjectionTestBase):
 
     def setUp(self):
         super(LoggingTests, self).setUp()
-        self.repo.knowsByLocation.return_value = True
+        #self.repo.byLocation.return_value = True
         self.opts = Mock()
         self.opts.dryrun = False
         img = Mock()
@@ -29,7 +29,7 @@ class LoggingTests(DependencyInjectionTestBase):
             self.provenancesAdded.append(provenance)
             self.newimg = Mock()
             self.newimg.provenance = {'acquired':location}
-            return (self.newimg, 'test')
+            return self.newimg
         self.dependencies.reconfigureOrGetConfiguration.return_value = self.opts
         patcher = patch('niprov.logging.add')
         self.add = patcher.start()
@@ -132,7 +132,7 @@ class LoggingTests(DependencyInjectionTestBase):
         self.assertEqual(self.provenancesAdded[1]['parents'], ['l:p1','l:p2'])
 
     def test_Add_parent_if_parent_unknown(self):
-        self.repo.knowsByLocation.return_value = False
+        self.repo.byLocation.return_value = None
         self.locationFactory.completeString.side_effect = lambda p: 'l:'+p
         provenance = self.log('new', 'trans', 'parentpath')
         self.add.assert_any_call('l:parentpath')
@@ -141,17 +141,15 @@ class LoggingTests(DependencyInjectionTestBase):
     def test_Uses_validated_location_for_parent_lookup(self):
         self.locationFactory.completeString.side_effect = lambda p: 'l:'+p
         provenance = self.log('new', 'trans', 'parentpath')
-        self.repo.knowsByLocation.assert_called_with('l:parentpath')
         self.repo.byLocation.assert_called_with('l:parentpath')
 
     def test_If_parent_unknown_uses_add_return_value(self):
         """In this case the parent provenance should be obtained from
         what add() returns.
         """
-        self.repo.knowsByLocation.return_value = False
+        self.repo.byLocation.return_value = None
         parent = 'unknown/parent/path.f'
         provenance = self.log('new', 'trans', [parent])
-        assert not self.repo.byLocation.called
         loggedFileProv = self.provenancesAdded[1] # [0]: parent [1]: newly logged
         ## add function is mocked to set 'acquired' field to location passed
         ## since acquired is an inheritable field, it should show up in kid:

--- a/tests/test_parrec.py
+++ b/tests/test_parrec.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy
 from mock import Mock, sentinel
-from datetime import datetime, timedelta
+from datetime import datetime
 from tests.test_basefile import BaseFileTests
 
 
@@ -34,7 +34,7 @@ class ParrecTests(BaseFileTests):
         self.assertEqual(out['epi-factor'], 1)
         self.assertEqual(out['magnetization-transfer-contrast'], False)
         self.assertEqual(out['diffusion'], False)
-        self.assertEqual(out['duration'], timedelta(seconds=65))
+        self.assertEqual(out['duration'], 65)
         self.assertEqual(out['subject-position'], 'Head First Supine')
         self.assertEqual(out['water-fat-shift'], 1.117)
         # per-image

--- a/tests/test_webviews.py
+++ b/tests/test_webviews.py
@@ -112,6 +112,17 @@ class ViewTests(DependencyInjectionTestBase):
         self.assertEqual('user', out['category'])
         self.assertEqual(self.query.allUsers(), out['items'])
 
+    def test_If_byId_byLocation_return_None_views_return_404(self):
+        from pyramid.httpexceptions import HTTPNotFound
+        import niprov.views
+        self.request.matchdict = {'host':'her','path':('a','b','c'),
+                                    'id':'1a2b3c'}
+        self.repo.byId.return_value = None
+        self.repo.byLocation.return_value = None
+        self.assertRaises(HTTPNotFound, niprov.views.short, self.request)
+        self.assertRaises(HTTPNotFound, niprov.views.location, self.request)
+        self.assertRaises(HTTPNotFound, niprov.views.pipeline, self.request)
+
 
 
 


### PR DESCRIPTION
fix #61 

- [x] add() 
- [x] series.addFile returns series
- [x] getSeries should return None inmediately if no seriesUid
- [x] get rid of "knowsXYZ" methods and tests
- [x] test_byLocation_works_for_file_in_series
- [x] byLocation, getSeries, etc should not inform listener or throw error??
- [x] web views should be mindful of repo retrurning None
- [x] listener.fileAdded
- [x] discovery adapt to status 
- [x] status = new
- [x] status = series
- [x] status = new version
- [x] BaseFile.keepVersionsFromPrevious() 
- [x] history access on instance
- [x] adapt approval
- [x] JsonFile serialize versions
- [x] mergeWith
- [x] get rid of timedeltas
- [x] history browsing on web view; show list of added datetimes;
