### PR TITLE
Copy as parent

### DIFF
--- a/acceptance/test_contextAPI.py
+++ b/acceptance/test_contextAPI.py
@@ -128,7 +128,15 @@ class ContextApiTests(unittest.TestCase):
         self.assertEqual(1, img.versions[-2]['a'])
 
     def test_If_no_parent_provided_found_copy_considered_parent(self):
-        self.fail()
+        self.provenance.add('testdata/eeg/stub.cnt')
+        self.touch('temp/orig.f')
+        self.provenance.log('temp/orig.f', 'op1', 'testdata/eeg/stub.cnt')
+        shutil.copy('temp/orig.f', 'temp/copy.f')
+        self.touch('temp/child.f')
+        child = self.provenance.log('temp/child.f', 'op2', 'temp/copy.f')
+        self.assertEqual(child.provenance['subject'], 'Jane Doe')
+        copy = self.provenance.get().byLocation('temp/copy.f')
+        self.assertIn(copy.provenance['parents'][0], ['Jane Doe'])
  
 
 if __name__ == '__main__':

--- a/acceptance/test_contextAPI.py
+++ b/acceptance/test_contextAPI.py
@@ -136,7 +136,7 @@ class ContextApiTests(unittest.TestCase):
         child = self.provenance.log('temp/child.f', 'op2', 'temp/copy.f')
         self.assertEqual(child.provenance['subject'], 'Jane Doe')
         copy = self.provenance.get().byLocation('temp/copy.f')
-        self.assertIn(copy.provenance['parents'][0], ['Jane Doe'])
+        self.assertIn('temp/orig.f', copy.provenance['parents'][0])
  
 
 if __name__ == '__main__':

--- a/acceptance/test_contextAPI.py
+++ b/acceptance/test_contextAPI.py
@@ -126,6 +126,9 @@ class ContextApiTests(unittest.TestCase):
         self.assertEqual(3, img.provenance['a'])
         self.assertEqual(2, img.versions[-1]['a'])
         self.assertEqual(1, img.versions[-2]['a'])
+
+    def test_If_no_parent_provided_found_copy_considered_parent(self):
+        self.fail()
  
 
 if __name__ == '__main__':

--- a/niprov/adding.py
+++ b/niprov/adding.py
@@ -41,6 +41,7 @@ def add(filepath, transient=False, provenance=None,
     repository = dependencies.getRepository()
     listener = dependencies.getListener()
     filesys = dependencies.getFilesystem()
+    query = dependencies.getQuery()
 
     if provenance is None:
         provenance = {}
@@ -63,6 +64,15 @@ def add(filepath, transient=False, provenance=None,
             return img
         if config.attach:
             img.attach(config.attach_format)
+
+    if not provenance.get('parents', []):
+        for copy in query.copiesOf(img):
+            if not copy.location == img.location:
+                img.inheritFrom(copy)
+                img.provenance['parents'] = [copy.location.toString()]
+                img.provenance['copy-as-parent'] = True
+                listener.usingCopyAsParent(copy)
+                break
 
     previousVersion = repository.byLocation(img.location.toString())
     series = repository.getSeries(img)

--- a/niprov/adding.py
+++ b/niprov/adding.py
@@ -4,6 +4,7 @@ import os, errno
 import shortuuid
 from datetime import datetime
 from niprov.dependencies import Dependencies
+from niprov.inheriting import inheritFrom
 
 
 def add(filepath, transient=False, provenance=None, 
@@ -68,7 +69,7 @@ def add(filepath, transient=False, provenance=None,
     if not provenance.get('parents', []):
         for copy in query.copiesOf(img):
             if not copy.location == img.location:
-                img.inheritFrom(copy)
+                inheritFrom(img.provenance, copy.provenance)
                 img.provenance['parents'] = [copy.location.toString()]
                 img.provenance['copy-as-parent'] = True
                 listener.usingCopyAsParent(copy)

--- a/niprov/commandline.py
+++ b/niprov/commandline.py
@@ -14,6 +14,10 @@ class Commandline(object):
         self.verbosity = dependencies.config.verbosity
         assert self.verbosity in self.vlevels, "Unknown verbosity value"
 
+    def usingCopyAsParent(self, copy):
+        loc = str(copy.location)
+        self.log('warning', 'Used provenance from copy found at '+loc)
+
     def fileAdded(self, image):
         if image.status == 'new':
             self.log('info', 'New file: {0}'.format(image.path))

--- a/niprov/inheriting.py
+++ b/niprov/inheriting.py
@@ -1,0 +1,23 @@
+
+
+def inheritFrom(provenance, parentProvenance):
+    inheritableFields = [
+    'acquired',
+    'subject',
+    'protocol',
+    'technique',
+    'repetition-time',
+    'epi-factor',
+    'magnetization-transfer-contrast',
+    'diffusion',
+    'echo-time',
+    'flip-angle',
+    'inversion-time',
+    'duration',
+    'subject-position',
+    'water-fat-shift',
+    ]
+    for field in inheritableFields:
+        if field in parentProvenance:
+            provenance[field] = parentProvenance[field]
+    return provenance

--- a/niprov/location.py
+++ b/niprov/location.py
@@ -29,3 +29,12 @@ class Location(object):
 
     def toString(self):
         return ':'.join([self.hostname, self.path])
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return str(self) == str(other)
+        else:
+            return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)

--- a/niprov/logging.py
+++ b/niprov/logging.py
@@ -2,6 +2,7 @@
 # -*- coding: UTF-8 -*-
 from niprov.dependencies import Dependencies
 from niprov.adding import add
+from niprov.inheriting import inheritFrom
 import copy
 
 
@@ -62,22 +63,6 @@ def log(new, transformation, parents, code=None, logtext=None, transient=False,
         provenance = {}
 
     #gather provenance common to all new files
-    inheritableFields = [
-    'acquired',
-    'subject',
-    'protocol',
-    'technique',
-    'repetition-time',
-    'epi-factor',
-    'magnetization-transfer-contrast',
-    'diffusion',
-    'echo-time',
-    'flip-angle',
-    'inversion-time',
-    'duration',
-    'subject-position',
-    'water-fat-shift',
-    ]
     parents = [location.completeString(p) for p in parents]
     commonProvenance = provenance
     commonProvenance['parents'] = parents
@@ -92,9 +77,8 @@ def log(new, transformation, parents, code=None, logtext=None, transient=False,
     if parent is None:
         parent = add(parents[0])
         listener.addUnknownParent(parents[0])
-    for field in inheritableFields:
-        if field in parent.provenance:
-            commonProvenance[field] = parent.provenance[field]
+
+    inheritFrom(commonProvenance, parent.provenance)
 
     # do things specific to each new file
     newImages = []

--- a/niprov/logging.py
+++ b/niprov/logging.py
@@ -75,7 +75,7 @@ def log(new, transformation, parents, code=None, logtext=None, transient=False,
         commonProvenance['logtext'] = logtext
     parent = repository.byLocation(parents[0])
     if parent is None:
-        parent = add(parents[0])
+        parent = add(parents[0], dependencies=dependencies)
         listener.addUnknownParent(parents[0])
 
     inheritFrom(commonProvenance, parent.provenance)

--- a/niprov/querying.py
+++ b/niprov/querying.py
@@ -77,3 +77,12 @@ class Query(object):
     def allUsers(self):
         self.fields.append(self._fieldAllValues('user'))
         return self
+
+    def copiesOf(self, target):
+        checksum = target.provenance.get('hash', None)
+        filesize = target.provenance.get('size', 0)
+        if checksum and filesize > 0:
+            self.fields.append(self._fieldHasValue('hash', checksum))
+        else:
+            self.cachedResults = []
+        return self

--- a/niprov/templates/single.mako
+++ b/niprov/templates/single.mako
@@ -15,9 +15,10 @@
 <%! import os %>
 <h1>${os.path.basename(image.provenance['path'])}</h1>
 
-<a href="${request.route_url('pipeline',id=image.provenance.get('id'))}">view pipeline
+<a href="${request.route_url('pipeline',id=image.provenance.get('id'))}">pipeline
     <img class="linkicon" src="${request.static_url('niprov:static/pipeline-link.svg')}" alt="pipeline"/></a>
 <a href="#versions">versions</a>
+<a href="#copies">copies</a>
 
 % if image.getSnapshotFilepath():
     <img class="snapshot" src="${request.static_url(image.getSnapshotFilepath())}" alt="snapshot"/>
@@ -49,6 +50,15 @@
     <dt>number of files</dt><dd>${len(image.provenance['filesInSeries'])}</dd>
 % endif
 </dl>
+
+<h2 id="copies">copies</h2>
+<ul>
+% for copy in copies:
+    <li>
+        <a href="${request.route_url('location',host=copy.provenance.get('hostname'),path=copy.provenance.get('path'))}">${copy.provenance.get('location')}</a>
+    </li>
+% endfor
+</ul>
 
 <h2 id="versions">versions</h2>
 <ol>

--- a/niprov/views.py
+++ b/niprov/views.py
@@ -17,20 +17,21 @@ def latest(request):
 def short(request):
     sid = request.matchdict['id']
     repository = request.dependencies.getRepository()
+    query = request.dependencies.getQuery()
     image = repository.byId(sid)
     if not image:
         raise HTTPNotFound
-    return {'image': image}
+    return {'image': image, 'copies': query.copiesOf(image)}
 
 @view_config(route_name='location', renderer='templates/single.mako')
 def location(request):
     path = os.sep + os.path.join(*request.matchdict['path'])
     loc = request.matchdict['host'] + ':' + path
-    repository = request.dependencies.getRepository()
-    image = repository.byLocation(loc)
+    query = request.dependencies.getQuery()
+    image = query.byLocation(loc)
     if not image:
         raise HTTPNotFound
-    return {'image': image}
+    return {'image': image, 'copies': query.copiesOf(image)}
 
 @view_config(route_name='stats', renderer='templates/stats.mako')
 def stats(request):

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -53,3 +53,15 @@ class CommandlineTests(DependencyInjectionTestBase):
         cmd.fileAdded(img)
         cmd.log.assert_called_with('info', 'Added new version for: xyz')
 
+    def test_usingCopyAsParent(self):
+        from niprov.commandline import Commandline
+        self.dependencies.config.verbosity = 'info'
+        cmd = Commandline(self.dependencies)
+        cmd.log = Mock()
+        copy = Mock()
+        copy.location = 'moon:/copy/location'
+        cmd.usingCopyAsParent(copy)
+        cmd.log.assert_called_with('warning', 
+            'Used provenance from copy found at '+str(copy.location))
+        
+

--- a/tests/test_inheriting.py
+++ b/tests/test_inheriting.py
@@ -1,0 +1,40 @@
+from tests.ditest import DependencyInjectionTestBase
+from mock import Mock, sentinel
+from datetime import datetime
+
+class InheritanceTests(DependencyInjectionTestBase):
+
+    def setUp(self):
+        super(InheritanceTests, self).setUp()
+
+    def test_InheritFrom(self):
+        from niprov.inheriting import inheritFrom
+        parentProv = {'acquired':datetime.now(),
+            'subject':'JD', 
+            'protocol':'X',
+            'technique':'abc',
+            'repetition-time':1.0,
+            'epi-factor':1.0,
+            'magnetization-transfer-contrast':True,
+            'diffusion':True,
+            'echo-time':123,
+            'flip-angle':892,
+            'inversion-time':123}
+        prov = inheritFrom({'a':1}, parentProv)
+        self.assertEqual(prov['acquired'], parentProv['acquired'])
+        self.assertEqual(prov['subject'], parentProv['subject'])
+        self.assertEqual(prov['protocol'], parentProv['protocol'])
+        self.assertEqual(prov['technique'], parentProv['technique'])
+        self.assertEqual(prov['repetition-time'], parentProv['repetition-time'])
+        self.assertEqual(prov['epi-factor'], parentProv['epi-factor'])
+        self.assertEqual(prov['magnetization-transfer-contrast'], 
+            parentProv['magnetization-transfer-contrast'])
+        self.assertEqual(prov['diffusion'], parentProv['diffusion'])
+        self.assertEqual(prov['echo-time'], parentProv['echo-time'])
+        self.assertEqual(prov['flip-angle'], parentProv['flip-angle'])
+        self.assertEqual(prov['inversion-time'], parentProv['inversion-time'])
+
+    def test_Doesnt_complain_if_parent_is_missing_basic_fields(self):
+        from niprov.inheriting import inheritFrom
+        prov = inheritFrom({'a':1}, {'b':2})
+

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -68,3 +68,11 @@ class LocationTests(DependencyInjectionTestBase):
                 self.assertEqual('/absolute/path', loc.path)
                 self.assertEqual('KITT:/absolute/path', str(loc))
 
+    def test_location_equals(self):
+        from niprov.location import Location
+        loc1 = Location('relative/path')
+        loc2 = Location('relative/path')
+        loc3 = Location('relative/other/path')
+        self.assertEqual(loc1, loc2)
+        self.assertNotEqual(loc1, loc3)
+

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -98,7 +98,7 @@ class LoggingTests(DependencyInjectionTestBase):
         self.repo.byLocation.return_value = None
         self.locationFactory.completeString.side_effect = lambda p: 'l:'+p
         provenance = self.log('new', 'trans', 'parentpath')
-        self.add.assert_any_call('l:parentpath')
+        self.add.assert_any_call('l:parentpath', dependencies=self.dependencies)
         self.listener.addUnknownParent.assert_called_with('l:parentpath')
 
     def test_Uses_validated_location_for_parent_lookup(self):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -120,5 +120,21 @@ class QueryTest(DependencyInjectionTestBase):
         self.assertEqual('project', q.getFields()[0].name)
         self.assertTrue(q.getFields()[0].all)
 
+    def test_copiesOf_returns_empty_list_for_size_0_file(self):
+        from niprov.querying import Query
+        target = Mock()
+        target.provenance = {'size':0}
+        results = Query(self.dependencies).copiesOf(target)
+        self.assertEqual(0, len(results))
+
+    def test_copiesOf(self):
+        from niprov.querying import Query
+        target = Mock()
+        target.provenance = {'hash':'a7b8c9', 'size':1}
+        q = Query(self.dependencies).copiesOf(target)
+        self.assertEqual(1, len(q.getFields()))
+        self.assertEqual('hash', q.getFields()[0].name)
+        self.assertEqual('a7b8c9', q.getFields()[0].value)
+
 
 

--- a/tests/test_webviews.py
+++ b/tests/test_webviews.py
@@ -23,13 +23,17 @@ class ViewTests(DependencyInjectionTestBase):
         out = niprov.views.short(self.request)
         self.repo.byId.assert_called_with('1a2b3c')
         self.assertEqual(self.repo.byId(), out['image'])
+        self.query.copiesOf.assert_called_with(out['image'])
+        self.assertEqual(self.query.copiesOf(), out['copies'])
 
     def test_by_full_location(self):
         import niprov.views
         self.request.matchdict = {'host':'her','path':('a','b','c')}
         out = niprov.views.location(self.request)
-        self.repo.byLocation.assert_called_with('her:/a/b/c')
-        self.assertEqual(self.repo.byLocation(), out['image'])
+        self.query.byLocation.assert_called_with('her:/a/b/c')
+        self.query.copiesOf.assert_called_with(out['image'])
+        self.assertEqual(self.query.byLocation(), out['image'])
+        self.assertEqual(self.query.copiesOf(), out['copies'])
 
     def test_stats(self):
         import niprov.views
@@ -118,7 +122,7 @@ class ViewTests(DependencyInjectionTestBase):
         self.request.matchdict = {'host':'her','path':('a','b','c'),
                                     'id':'1a2b3c'}
         self.repo.byId.return_value = None
-        self.repo.byLocation.return_value = None
+        self.query.byLocation.return_value = None
         self.assertRaises(HTTPNotFound, niprov.views.short, self.request)
         self.assertRaises(HTTPNotFound, niprov.views.location, self.request)
         self.assertRaises(HTTPNotFound, niprov.views.pipeline, self.request)


### PR DESCRIPTION
fixes #92 

- [x] getCopies()
- [x] getCopies() doesnt return anything for files of 0 bytes.
- [x] inheritFrom()
- [x] location equals
- [x] log uses inheritFrom
- [x] sets copy location on `parents` field
- [x] sets flag to indicate copy relationship
- [x] details page lists copies